### PR TITLE
added pam_sm_setcred service function

### DIFF
--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -206,5 +206,9 @@ done:
 
   return retval;
 
+}
 
+PAM_EXTERN int 
+pam_sm_setcred(pam_handle_t *pamh, int flags, int argc, const char **argv){
+  return PAM_SUCCESS;
 }

--- a/pam_u2f.8.txt
+++ b/pam_u2f.8.txt
@@ -24,7 +24,7 @@ Set the origin for the U2F authentication procedure. If no value is specified, t
 Set the application ID for the U2F authentication procedure. If no value is specified, the same value used for origin is taken ("pam://$HOSTNAME" if also origin is not specified).
 
 *authfile*=_file_::
-Set the location of the file that holds the mappings of user names to keyHandles and user keys.  The format is username:number_of_devices:first_keyHandle,first_public_key:second_keyHandle,second_public_key:...  default location of the file is $HOME/.yubico/u2f_keys.
+Set the location of the file that holds the mappings of user names to keyHandles and user keys.  The format is username:first_keyHandle,first_public_key:second_keyHandle,second_public_key:...  default location of the file is $HOME/.yubico/u2f_keys.
 
 *nouserok*::
 Set to enable authentication attempts to succeed even if the user trying to authenticate is not found inside authfile.


### PR DESCRIPTION
add the pam_sm_setcred service function to pam-u2f. Fedora 21 calls this function after a successful authentication. Not sure why this happens but a similar function is also in pam_yubico. 