### PR TITLE
Add libpam to dependencies in readme

### DIFF
--- a/README
+++ b/README
@@ -56,10 +56,10 @@ This will create a directory 'pam-u2f'. Enter the directory:
   $ cd pam-u2f
 -----------
 
-Autoconf, automake and libtool must be installed. AsciiDoc is used to
+Autoconf, automake, libtool, and libpam must be installed. AsciiDoc is used to
 generate the manpages.
 
-  Debian:   apt-get install autoconf automake libtool asciidoc
+  Debian:   apt-get install autoconf automake libtool libpam-dev asciidoc
 
 Generate the build system using:
 

--- a/README
+++ b/README
@@ -59,7 +59,7 @@ This will create a directory 'pam-u2f'. Enter the directory:
 Autoconf, automake, libtool, and libpam must be installed. AsciiDoc is used to
 generate the manpages.
 
-  Debian:   apt-get install autoconf automake libtool libpam-dev asciidoc
+  Debian:   apt-get install autoconf automake libtool libpam-dev asciidoc --no-install-recommends
 
 Generate the build system using:
 

--- a/README
+++ b/README
@@ -56,10 +56,10 @@ This will create a directory 'pam-u2f'. Enter the directory:
   $ cd pam-u2f
 -----------
 
-Autoconf, automake, libtool, and libpam must be installed. AsciiDoc is used to
+Autoconf, automake, libtool, and libpam must be installed. AsciiDoc and xsltproc are used to
 generate the manpages.
 
-  Debian:   apt-get install autoconf automake libtool libpam-dev asciidoc --no-install-recommends
+  Debian:   apt-get install autoconf automake libtool libpam-dev asciidoc xsltproc --no-install-recommends
 
 Generate the build system using:
 


### PR DESCRIPTION
Add libpam to dependencies and allso `--no-install-recommends` so that users don't accidentally install an extra GB of packages.