### PR TITLE
add interactive mode

### DIFF
--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -29,6 +29,8 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t * cfg)
       cfg->nouserok = 1;
     if (strcmp(argv[i], "alwaysok") == 0)
       cfg->alwaysok = 1;
+    if (strcmp(argv[i], "interactive") == 0)
+      cfg->interactive = 1;
     if (strncmp(argv[i], "authfile=", 9) == 0)
       cfg->auth_file = argv[i] + 9;
     if (strncmp(argv[i], "origin=", 7) == 0)
@@ -44,6 +46,7 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t * cfg)
       D(("argv[%d]=%s", i, argv[i]));
     D(("max_devices=%d", cfg->max_devs));
     D(("debug=%d", cfg->debug));
+    D(("interactive=%d", cfg->interactive));
     D(("nouserok=%d", cfg->nouserok));
     D(("alwaysok=%d", cfg->alwaysok));
     D(("authfile=%s", cfg->auth_file ? cfg->auth_file : "(null)"));
@@ -210,6 +213,11 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
       retval = PAM_AUTHINFO_UNAVAIL;
       goto done;
     }
+  }
+
+  if (cfg->interactive) {
+    printf("Insert your U2F device, then press ENTER.\n");
+    while (getchar() != 10);
   }
 
   retval = do_authentication(cfg, devices, n_devices);

--- a/util.c
+++ b/util.c
@@ -304,3 +304,87 @@ int do_authentication(const cfg_t * cfg, const device_t * devices,
   return retval;
 
 }
+
+#define MAX_RESPONSE_LEN (1024)
+
+int do_manual_authentication(const cfg_t * cfg, const device_t * devices,
+                      const unsigned n_devs)
+{
+  u2fs_ctx_t *ctx_arr[n_devs];
+  u2fs_auth_res_t *auth_result;
+  u2fs_rc s_rc;
+  char response[MAX_RESPONSE_LEN];
+  char *buf;
+  int retval = -2;
+  unsigned i = 0;
+
+  if (u2fs_global_init(0) != U2FS_OK) {
+    D(("Unable to initialize libu2f-server"));
+    return retval;
+  }
+
+  for(i = 0; i < n_devs; ++i) {
+
+    if (u2fs_init(ctx_arr + i) != U2FS_OK) {
+      D(("Unable to initialize libu2f-server"));
+      return retval;
+    }
+    
+    if ((s_rc = u2fs_set_origin(ctx_arr[i], cfg->origin)) != U2FS_OK) {
+      D(("Unable to set origin: %s", u2fs_strerror(s_rc)));
+      return retval;
+    }
+
+    if ((s_rc = u2fs_set_appid(ctx_arr[i], cfg->appid)) != U2FS_OK) {
+      D(("Unable to set appid: %s", u2fs_strerror(s_rc)));
+      return retval;
+    }
+    
+    if (cfg->debug)
+      D(("Attempting authentication with device number %d", i + 1));
+
+    if ((s_rc = u2fs_set_keyHandle(ctx_arr[i], devices[i].keyHandle)) != U2FS_OK) {
+      D(("Unable to set keyHandle: %s", u2fs_strerror(s_rc)));
+      return retval;
+    }
+
+    if ((s_rc = u2fs_set_publicKey(ctx_arr[i], devices[i].publicKey)) != U2FS_OK) {
+      D(("Unable to set publicKey %s", u2fs_strerror(s_rc)));
+      return retval;
+    }
+
+    if ((s_rc = u2fs_authentication_challenge(ctx_arr[i], &buf)) != U2FS_OK) {
+      D(("Unable to produce authentication challenge: %s",
+         u2fs_strerror(s_rc)));
+      return retval;
+    }
+
+    if (cfg->debug)
+      D(("Challenge: %s", buf));
+
+    if ( !i )
+      printf("Now please copy-paste the below challenge(s) to 'u2f-host -aauthenticate -o %s'\n", cfg->origin);
+    puts(buf);
+    
+  }
+
+  puts("Now, please enter the response(s) below, one per line.\n");
+  retval = -1;
+  for (i = 0; i < n_devs; ++i) {
+    if (response != fgets(response, MAX_RESPONSE_LEN, stdin)) {
+	D(("fgets failed when processing the %d-th response", i));
+    }
+    if (u2fs_authentication_verify(ctx_arr[i], response, &auth_result)
+        == U2FS_OK) {
+      retval = 1;
+      break;
+    }
+  }
+
+  for (i = 0; i < n_devs; ++i)
+    u2fs_done(ctx_arr[i]);
+  u2fs_global_done();
+
+  return retval;
+
+}

--- a/util.h
+++ b/util.h
@@ -35,6 +35,7 @@
 typedef struct {
   unsigned max_devs;
   const char *client_key;
+  int manual;
   int debug;
   int nouserok;
   int alwaysok;
@@ -56,6 +57,8 @@ int get_devices_from_authfile(const char *authfile, const char *username,
 void free_devices(device_t * devices, const unsigned n_devs);
 
 int do_authentication(const cfg_t * cfg, const device_t * devices,
+                      const unsigned n_devs);
+int do_manual_authentication(const cfg_t * cfg, const device_t * devices,
                       const unsigned n_devs);
 
 #endif                          /* UTIL_H */

--- a/util.h
+++ b/util.h
@@ -38,6 +38,7 @@ typedef struct {
   int debug;
   int nouserok;
   int alwaysok;
+  int interactive;
   const char *auth_file;
   const char *origin;
   const char *appid;


### PR DESCRIPTION
Add an interactive mode such that the device checking only starts after user press ENTER on a message like "Press ENTER to check against your U2F Authenticator", which is useful because some keys are set to deactivates itself after several seconds of connection to the USB port.

(#issue 10)