### PR TITLE
Manual mode & interactive

### DIFF
--- a/README
+++ b/README
@@ -118,11 +118,11 @@ max_devices=n_devices::
 Maximum number of devices allowed per user (default is 24). Devices specified
 in the authentication file that exceed this value will be ignored.
 
-*interactive*::
+interactive::
 Set to prompt a message and wait before testing the presence of a U2F device. Recommended
 if your device doesn't have a button.
 
-*manual*::
+manual::
 Set to drop to a manual console where challenges are printed on screen
 and response input from keyboard. Useful for debugging and SSH sessions without
 U2F-supporting from SSH client/server.

--- a/README
+++ b/README
@@ -118,6 +118,15 @@ max_devices=n_devices::
 Maximum number of devices allowed per user (default is 24). Devices specified
 in the authentication file that exceed this value will be ignored.
 
+*interactive*::
+Set to prompt a message and wait before testing the presence of a U2F device. Recommended
+if your device doesn't have a button.
+
+*manual*::
+Set to drop to a manual console where challenges are printed on screen
+and response input from keyboard. Useful for debugging and SSH sessions without
+U2F-supporting from SSH client/server.
+
 [[files]]
 Authorization Mapping Files
 ---------------------------

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -220,8 +220,9 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
 
   if (cfg->manual == 0) {
     if (cfg->interactive) {
-      printf("Insert your U2F device, then press ENTER.\n");
-      while (getchar() != 10);
+      //printf("Insert your U2F device, then press ENTER.\n");
+      //while (getchar() != 10);
+      const char *p = converse(pamh, PAM_TEXT_INFO, "Insert your U2F device, then press ENTER.\n");
     }
 
     retval = do_authentication(cfg, devices, n_devices);

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -29,6 +29,8 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t * cfg)
       cfg->nouserok = 1;
     if (strcmp(argv[i], "alwaysok") == 0)
       cfg->alwaysok = 1;
+    if (strcmp(argv[i], "interactive") == 0)
+      cfg->interactive = 1;
     if (strncmp(argv[i], "authfile=", 9) == 0)
       cfg->auth_file = argv[i] + 9;
     if (strncmp(argv[i], "origin=", 7) == 0)
@@ -44,6 +46,7 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t * cfg)
       D(("argv[%d]=%s", i, argv[i]));
     D(("max_devices=%d", cfg->max_devs));
     D(("debug=%d", cfg->debug));
+    D(("interactive=%d", cfg->interactive));
     D(("nouserok=%d", cfg->nouserok));
     D(("alwaysok=%d", cfg->alwaysok));
     D(("authfile=%s", cfg->auth_file ? cfg->auth_file : "(null)"));
@@ -210,6 +213,11 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
       retval = PAM_AUTHINFO_UNAVAIL;
       goto done;
     }
+  }
+
+  if (cfg->interactive) {
+    printf("Insert your U2F device, then press ENTER.\n");
+    while (getchar() != 10);
   }
 
   retval = do_authentication(cfg, devices, n_devices);

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -222,12 +222,12 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
     if (cfg->interactive) {
       //printf("Insert your U2F device, then press ENTER.\n");
       //while (getchar() != 10);
-      const char *p = converse(pamh, PAM_TEXT_INFO, "Insert your U2F device, then press ENTER.\n");
+      const char *p = converse(pamh, PAM_PROMPT_ECHO_ON, "Insert your U2F device, then press ENTER.\n");
     }
 
     retval = do_authentication(cfg, devices, n_devices);
   } else {
-    retval = do_manual_authentication(cfg, devices, n_devices);
+    retval = do_manual_authentication(cfg, devices, n_devices, pamh);
   }
   if (retval != 1) {
     DBG(("do_authentication returned %d", retval));

--- a/pam_u2f.8.txt
+++ b/pam_u2f.8.txt
@@ -36,6 +36,15 @@ Set to enable all authentication attempts to succeed (aka presentation mode).
 Maximum number of devices allowed per user (default is 24). Devices specified
 in the authentication file that exceed this value will be ignored.
 
+*interactive*::
+Set to prompt a message and wait before testing the presence of a U2F device. Recommended
+if your device doesn't have a button.
+
+*manual*::
+Set to drop to a manual console where challenges are printed on screen
+and response input from keyboard. Useful for debugging and SSH sessions without
+U2F-supporting from SSH client/server.
+
 == EXAMPLES
 
 auth sufficient pam_u2f.so debug origin=pam://$HOSTNAME appid=pam://$HOSTNAME

--- a/util.c
+++ b/util.c
@@ -381,6 +381,7 @@ int do_manual_authentication(const cfg_t * cfg, const device_t * devices,
         u2fs_authentication_verify(ctx_arr[i], response, &auth_result)
         == U2FS_OK) {
       retval = 1;
+      break;
     }
     free(response);
   }

--- a/util.c
+++ b/util.c
@@ -373,7 +373,7 @@ int do_manual_authentication(const cfg_t * cfg, const device_t * devices,
 
   converse(pamh, PAM_TEXT_INFO, "Now, please enter the response(s) below, one per line.");
   retval = -1;
-  for (i = 0; i < n_devs; ++i) {
+  for (i = 0; (i < n_devs) && (retval != 1); ++i) {
     sprintf(prompt, "[%d]: ", i);
     response = converse(pamh, PAM_PROMPT_ECHO_ON, prompt);
     converse(pamh, PAM_TEXT_INFO, response);
@@ -381,7 +381,6 @@ int do_manual_authentication(const cfg_t * cfg, const device_t * devices,
         u2fs_authentication_verify(ctx_arr[i], response, &auth_result)
         == U2FS_OK) {
       retval = 1;
-      break;
     }
     free(response);
   }
@@ -415,7 +414,7 @@ char *converse(pam_handle_t *pamh, int echocode,
   char *ret = NULL;
   if (retval != PAM_SUCCESS || resp == NULL || resp->resp == NULL ||
       *resp->resp == '\000') {
-    D(("Did not receive verification code from user"));
+    D(("Failed to get response from user input!"));
     if (retval == PAM_SUCCESS && resp && resp->resp) {
       ret = resp->resp;
     }
@@ -423,7 +422,7 @@ char *converse(pam_handle_t *pamh, int echocode,
     ret = resp->resp;
   }
 
-  // Deallocate temporary storage
+  // Deallocate temporary storage.
   if (resp) {
     if (!ret) {
       free(resp->resp);

--- a/util.c
+++ b/util.c
@@ -304,3 +304,87 @@ int do_authentication(const cfg_t * cfg, const device_t * devices,
   return retval;
 
 }
+
+#define MAX_RESPONSE_LEN (1024)
+
+int do_manual_authentication(const cfg_t * cfg, const device_t * devices,
+                      const unsigned n_devs)
+{
+  u2fs_ctx_t *ctx_arr[n_devs];
+  u2fs_auth_res_t *auth_result;
+  u2fs_rc s_rc;
+  char response[MAX_RESPONSE_LEN];
+  char *buf;
+  int retval = -2;
+  unsigned i = 0;
+
+  if (u2fs_global_init(0) != U2FS_OK) {
+    D(("Unable to initialize libu2f-server"));
+    return retval;
+  }
+
+  for(i = 0; i < n_devs; ++i) {
+
+    if (u2fs_init(ctx_arr + i) != U2FS_OK) {
+      D(("Unable to initialize libu2f-server"));
+      return retval;
+    }
+    
+    if ((s_rc = u2fs_set_origin(ctx_arr[i], cfg->origin)) != U2FS_OK) {
+      D(("Unable to set origin: %s", u2fs_strerror(s_rc)));
+      return retval;
+    }
+
+    if ((s_rc = u2fs_set_appid(ctx_arr[i], cfg->appid)) != U2FS_OK) {
+      D(("Unable to set appid: %s", u2fs_strerror(s_rc)));
+      return retval;
+    }
+    
+    if (cfg->debug)
+      D(("Attempting authentication with device number %d", i + 1));
+
+    if ((s_rc = u2fs_set_keyHandle(ctx_arr[i], devices[i].keyHandle)) != U2FS_OK) {
+      D(("Unable to set keyHandle: %s", u2fs_strerror(s_rc)));
+      return retval;
+    }
+
+    if ((s_rc = u2fs_set_publicKey(ctx_arr[i], devices[i].publicKey)) != U2FS_OK) {
+      D(("Unable to set publicKey %s", u2fs_strerror(s_rc)));
+      return retval;
+    }
+
+    if ((s_rc = u2fs_authentication_challenge(ctx_arr[i], &buf)) != U2FS_OK) {
+      D(("Unable to produce authentication challenge: %s",
+         u2fs_strerror(s_rc)));
+      return retval;
+    }
+
+    if (cfg->debug)
+      D(("Challenge: %s", buf));
+
+    if ( !i )
+      printf("Now please copy-paste the below challenge(s) to 'u2f-host -aauthenticate -o %s'\n", cfg->origin);
+    puts(buf);
+    
+  }
+
+  puts("Now, please enter the response(s) below, one per line.\n");
+  retval = -1;
+  for (i = 0; i < n_devs; ++i) {
+    if (response != fgets(response, MAX_RESPONSE_LEN, stdin)) {
+	D(("fgets failed when processing the %d-th response", i));
+    }
+    if (u2fs_authentication_verify(ctx_arr[i], response, &auth_result)
+        == U2FS_OK) {
+      retval = 1;
+      break;
+    }
+  }
+
+  for (i = 0; i < n_devs; ++i)
+    u2fs_done(ctx_arr[i]);
+  u2fs_global_done();
+
+  return retval;
+
+}

--- a/util.h
+++ b/util.h
@@ -6,6 +6,7 @@
 #define UTIL_H
 
 #include <stdio.h>
+#include <security/pam_appl.h>
 
 #define BUFSIZE 1024
 #define MAX_DEVS 24
@@ -59,7 +60,7 @@ void free_devices(device_t * devices, const unsigned n_devs);
 int do_authentication(const cfg_t * cfg, const device_t * devices,
                       const unsigned n_devs);
 int do_manual_authentication(const cfg_t * cfg, const device_t * devices,
-                      const unsigned n_devs);
+                      const unsigned n_devs, pam_handle_t * pamh);
 char *converse(pam_handle_t *pamh, int echocode,
-                          const char *prompt)
+                          const char *prompt);
 #endif                          /* UTIL_H */

--- a/util.h
+++ b/util.h
@@ -35,6 +35,7 @@
 typedef struct {
   unsigned max_devs;
   const char *client_key;
+  int manual;
   int debug;
   int nouserok;
   int alwaysok;
@@ -56,6 +57,8 @@ int get_devices_from_authfile(const char *authfile, const char *username,
 void free_devices(device_t * devices, const unsigned n_devs);
 
 int do_authentication(const cfg_t * cfg, const device_t * devices,
+                      const unsigned n_devs);
+int do_manual_authentication(const cfg_t * cfg, const device_t * devices,
                       const unsigned n_devs);
 
 #endif                          /* UTIL_H */

--- a/util.h
+++ b/util.h
@@ -60,5 +60,6 @@ int do_authentication(const cfg_t * cfg, const device_t * devices,
                       const unsigned n_devs);
 int do_manual_authentication(const cfg_t * cfg, const device_t * devices,
                       const unsigned n_devs);
-
+char *converse(pam_handle_t *pamh, int echocode,
+                          const char *prompt)
 #endif                          /* UTIL_H */

--- a/util.h
+++ b/util.h
@@ -38,6 +38,7 @@ typedef struct {
   int debug;
   int nouserok;
   int alwaysok;
+  int interactive;
   const char *auth_file;
   const char *origin;
   const char *appid;


### PR DESCRIPTION
Besides "interactive" this one adds a new manual mode where the challenges are printed on screen and responses retrieved via keyboard, which facilitates debugging and also enables a makeshift for SSH authentication (along with a patched libu2f-host which allows 'pam://' origins).
This patch also includes interactive mode, implemented using `pam_get_item`. Although the other patch I submitted would work as well by `printf`, `pam_get_item` is better for its portability.