### PR TITLE
Fix build issues on OS X

### DIFF
--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <pwd.h>
 #include <string.h>
+#include <errno.h>
 
 #include "util.h"
 

--- a/util.c
+++ b/util.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <errno.h>
 
 #include <string.h>
 


### PR DESCRIPTION
This patch fixes the following issues on OS X.

```
$ make
Making all in .
  CC       pam-u2f.lo
pam-u2f.c:147:19: error: use of undeclared identifier 'errno'
         strerror(errno)));
                  ^
pam-u2f.c:67:36: note: expanded from macro 'DBG'
#define DBG(x) if (cfg->debug) { D(x); }
                                   ^
./util.h:28:12: note: expanded from macro 'D'
    printf x;                                                         \
           ^
1 error generated.
make[1]: *** [pam-u2f.lo] Error 1
 12 /*
make: *** [all-recursive] Error 1
```

```
$ make
Making all in .
  CC       pam-u2f.lo
  CC       util.lo
util.c:33:58: error: use of undeclared identifier 'errno'
      D(("Cannot open file: %s (%s)", authfile, strerror(errno)));
                                                         ^
./util.h:28:12: note: expanded from macro 'D'
    printf x;                                                         \
           ^
util.c:39:58: error: use of undeclared identifier 'errno'
      D(("Cannot stat file: %s (%s)", authfile, strerror(errno)));
                                                         ^
./util.h:28:12: note: expanded from macro 'D'
    printf x;                                                         \
           ^
util.c:40:5: warning: implicit declaration of function 'close' is invalid in C99 [-Wimplicit-function-declaration]
    close(fd);
    ^
util.c:61:33: error: use of undeclared identifier 'errno'
      D(("fdopen: %s", strerror(errno)));
                                ^
./util.h:28:12: note: expanded from macro 'D'
    printf x;                                                         \
           ^
util.c:157:54: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
          D(("Length of key number %d is %d", i + 1, devices[i].key_len));
                                         ~~          ^~~~~~~~~~~~~~~~~~
                                         %zu
./util.h:28:12: note: expanded from macro 'D'
    printf x;                                                         \
           ^
util.c:452:12: warning: initializing 'char *' with an expression of type 'const char *' discards qualifiers
      [-Wincompatible-pointer-types-discards-qualifiers]
    .msg = prompt
           ^~~~~~
3 warnings and 3 errors generated.
make[1]: *** [util.lo] Error 1
make: *** [all-recursive] Error 1
```