### PR TITLE
Properly tag `perror()` call for `getlogin()`.

### DIFF
--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
   else {
     user = getlogin();
     if (!user) {
-      perror("gethostname");
+      perror("getlogin");
       exit(EXIT_FAILURE);
     }
   }


### PR DESCRIPTION
It was tagged as `gethostname()`.