### PR TITLE
Replaced getlogin with getuid and getpwuid to obtain username

### DIFF
--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -15,6 +15,8 @@
 #include <string.h>
 #include <getopt.h>
 #include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
 
 #include "cmdline.h"
 
@@ -32,6 +34,7 @@ int main(int argc, char *argv[])
   char *origin = NULL;
   char *appid = NULL;
   char *user = NULL;
+  struct passwd *passwd;
   const char *kh = NULL;
   const char *pk = NULL;
   u2fh_devs *devs = NULL;
@@ -106,11 +109,12 @@ int main(int argc, char *argv[])
   if (args_info.username_given)
     user = args_info.username_arg;
   else {
-    user = getlogin();
-    if (!user) {
-      perror("getlogin");
+    passwd = getpwuid(getuid());
+    if (passwd == NULL) {
+      perror("getpwuid");
       exit(EXIT_FAILURE);
     }
+    user = passwd->pw_name;
   }
 
   if (u2fh_global_init(args_info.debug_flag ? U2FS_DEBUG : 0) != U2FH_OK


### PR DESCRIPTION
I encountered a problem with `getlogin` failing like so:

    $ pamu2fcfg
    getlogin: No such file or directory

So I decided to investigate, [this StackOverflow answer](http://stackoverflow.com/questions/4785126/getlogin-c-function-returns-null-and-error-no-such-file-or-directory/4785195#4785195) informed me that `getlogin` was deprecated because of [the fact that it relies on a valid UTMP file](http://stackoverflow.com/questions/4785126/getlogin-c-function-returns-null-and-error-no-such-file-or-directory/4785186#4785186), which I didn't have apparently.

So I replaced `getlogin` with `getpwuid(getuid())` which returns a `struct passwd` (the `passwd` file entry for the current user) that I then use to get the username. Just a quick fix, tried and tested on my machine, hope it helps.