### PR TITLE
setup individual prompt message for interactive mode

### DIFF
--- a/README
+++ b/README
@@ -127,6 +127,10 @@ interactive::
 Set to prompt a message and wait before testing the presence of a U2F device.
 Recommended if your device doesn't have a tactile trigger.
 
+[prompt=your prompt here without newline]::
+Set individual prompt message for interactive mode. Watch the square brackets
+around this parameter to get spaces correct recognized by PAM.
+
 manual::
 Set to drop to a manual console where challenges are printed on screen
 and response read from standard input. Useful for debugging and SSH sessions

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -58,6 +58,8 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t * cfg)
       cfg->origin = argv[i] + 7;
     if (strncmp(argv[i], "appid=", 6) == 0)
       cfg->appid = argv[i] + 6;
+    if (strncmp(argv[i], "prompt=", 7) == 0)
+      cfg->prompt = argv[i] + 7;
   }
 
   if (cfg->debug) {
@@ -75,6 +77,7 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t * cfg)
     D(("authfile=%s", cfg->auth_file ? cfg->auth_file : "(null)"));
     D(("origin=%s", cfg->origin ? cfg->origin : "(null)"));
     D(("appid=%s", cfg->appid ? cfg->appid : "(null)"));
+    D(("prompt=%s", cfg->prompt ? cfg->prompt : "(null)"));
   }
 }
 
@@ -96,7 +99,9 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
   char buffer[BUFSIZE];
   char *buf = NULL;
   char *authfile_dir;
+  char *prompt = NULL;
   int authfile_dir_len;
+  int prompt_len;
   int pgu_ret, gpn_ret;
   int retval = PAM_IGNORE;
   device_t *devices = NULL;
@@ -250,8 +255,37 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
 
   if (cfg->manual == 0) {
     if (cfg->interactive) {
+      if (!cfg->prompt) {
+        buf = NULL;
+        prompt_len =
+            strlen(DEFAULT_PROMPT) + strlen("\n") + 1;
+        buf = malloc(sizeof(char) * (prompt_len));
+
+        if (!buf) {
+          DBG(("Unable to allocate memory"));
+          retval = PAM_IGNORE;
+          goto done;
+        }
+
+        strcpy(buf, DEFAULT_PROMPT);
+        strcat(buf, "\n");
+
+        DBG(("Using default prompt %s", buf));
+
+        cfg->prompt = strdup(buf);
+        if (!cfg->prompt) {
+          DBG(("Unable to allocate memory"));
+          retval = PAM_IGNORE;
+          goto done;
+        }
+
+      }
+
+      free(buf);
+      buf = NULL;
+
       converse(pamh, PAM_PROMPT_ECHO_ON,
-               "Insert your U2F device, then press ENTER.\n");
+               cfg->prompt);
     }
 
     retval = do_authentication(cfg, devices, n_devices, pamh);

--- a/util.h
+++ b/util.h
@@ -16,6 +16,7 @@
 #define DEVSIZE (((PK_LEN)+(KH_LEN)+(RD_LEN)))
 #define DEFAULT_AUTHFILE_DIR_VAR "XDG_CONFIG_HOME"
 #define DEFAULT_AUTHFILE "/Yubico/u2f_keys"
+#define DEFAULT_PROMPT "Insert your U2F device, then press ENTER."
 #define DEFAULT_ORIGIN_PREFIX "pam://"
 
 #if defined(DEBUG_PAM)
@@ -45,6 +46,7 @@ typedef struct {
   const char *auth_file;
   const char *origin;
   const char *appid;
+  const char *prompt;
 } cfg_t;
 
 typedef struct {


### PR DESCRIPTION
Would be nice to get in common an individual prompt for e.g. mention a key hint.
Feel free to enhance /modify it if didn't fit your module standard.

In my case there is the idea to have a quick solution for using 2 U2F keys to get 4-eyes principle / like PGP key sharing/splitting to require 2 developers signing in together on production servers with e.g. this lines:

````
auth requisite  pam_u2f.so authfile=/etc/u2f_mappings1 interactive [prompt=Insert your U2F key 1:]
auth sufficient pam_u2f.so authfile=/etc/u2f_mappings2 interactive [prompt=Insert your U2F key 2:]
````