### PR TITLE
Fix invalid memory access and memory leaks in get_devices_from_authfile

### DIFF
--- a/util.c
+++ b/util.c
@@ -185,7 +185,15 @@ int get_devices_from_authfile(const char *authfile, const char *username,
 
         for (j = 0; j < devices[i].key_len; j++) {
           unsigned int x;
-          sscanf(&s_token[2 * j], "%2x", &x);
+          if (sscanf(&s_token[2 * j], "%2x", &x) != 1) {
+            if (verbose)
+              D(("Invalid hex number in key"));
+            *n_devs = 0;
+            fclose(opwfile);
+            free(buf);
+            buf = NULL;
+            return retval;
+          }
           devices[i].publicKey[j] = (char)x;
         }
 

--- a/util.c
+++ b/util.c
@@ -106,10 +106,19 @@ int get_devices_from_authfile(const char *authfile, const char *username,
 
       retval = -1; // We found at least one line for the user
 
+      // only keep last line for this user
+      for (i = 0; i < *n_devs; i++) {
+        free(devices[i].keyHandle);
+        free(devices[i].publicKey);
+        devices[i].keyHandle = NULL;
+        devices[i].publicKey = NULL;
+      }
       *n_devs = 0;
 
       i = 0;
       while ((s_token = strtok_r(NULL, ",", &saveptr))) {
+        devices[i].keyHandle = NULL;
+        devices[i].publicKey = NULL;
 
         if ((*n_devs)++ > MAX_DEVS - 1) {
           *n_devs = MAX_DEVS;
@@ -183,6 +192,13 @@ int get_devices_from_authfile(const char *authfile, const char *username,
   goto out;
 
 err:
+  for (i = 0; i < *n_devs; i++) {
+    free(devices[i].keyHandle);
+    free(devices[i].publicKey);
+    devices[i].keyHandle = NULL;
+    devices[i].publicKey = NULL;
+  }
+
   *n_devs = 0;
 
 out:

--- a/util.c
+++ b/util.c
@@ -20,15 +20,15 @@ int get_devices_from_authfile(const char *authfile, const char *username,
                               unsigned max_devs, int verbose, device_t *devices,
                               unsigned *n_devs) {
 
-  char *buf;
+  char *buf = NULL;
   char *s_user, *s_token;
   int retval = 0;
-  int fd;
+  int fd = -1;
   struct stat st;
   struct passwd *pw = NULL, pw_s;
   char buffer[BUFSIZE];
   int gpu_ret;
-  FILE *opwfile;
+  FILE *opwfile = NULL;
   unsigned i, j;
 
   /* Ensure we never return uninitialized count. */
@@ -38,36 +38,32 @@ int get_devices_from_authfile(const char *authfile, const char *username,
   if (fd < 0) {
     if (verbose)
       D(("Cannot open file: %s (%s)", authfile, strerror(errno)));
-    return retval;
+    goto err;
   }
 
   if (fstat(fd, &st) < 0) {
     if (verbose)
       D(("Cannot stat file: %s (%s)", authfile, strerror(errno)));
-    close(fd);
-    return retval;
+    goto err;
   }
 
   if (!S_ISREG(st.st_mode)) {
     if (verbose)
       D(("%s is not a regular file", authfile));
-    close(fd);
-    return retval;
+    goto err;
   }
 
   if (st.st_size == 0) {
     if (verbose)
       D(("File %s is empty", authfile));
-    close(fd);
-    return retval;
+    goto err;
   }
 
   gpu_ret = getpwuid_r(st.st_uid, &pw_s, buffer, sizeof(buffer), &pw);
   if (gpu_ret != 0 || pw == NULL) {
     D(("Unable to retrieve credentials for uid %u, (%s)", st.st_uid,
        strerror(errno)));
-    close(fd);
-    return retval;
+    goto err;
   }
 
   if (strcmp(pw->pw_name, username) != 0 && strcmp(pw->pw_name, "root") != 0) {
@@ -77,25 +73,21 @@ int get_devices_from_authfile(const char *authfile, const char *username,
     } else {
       D(("The owner of the authentication file is not root"));
     }
-    close(fd);
-    return retval;
+    goto err;
   }
 
   opwfile = fdopen(fd, "r");
   if (opwfile == NULL) {
     if (verbose)
       D(("fdopen: %s", strerror(errno)));
-    close(fd);
-    return retval;
+    goto err;
   }
 
   buf = malloc(sizeof(char) * (DEVSIZE * max_devs));
   if (!buf) {
     if (verbose)
       D(("Unable to allocate memory"));
-    fclose(opwfile);
-    close(fd);
-    return retval;
+    goto err;
   }
 
   retval = -2;
@@ -135,11 +127,7 @@ int get_devices_from_authfile(const char *authfile, const char *username,
         if (!devices[i].keyHandle) {
           if (verbose)
             D(("Unable to allocate memory for keyHandle number %d", i));
-          *n_devs = 0;
-          fclose(opwfile);
-          free(buf);
-          buf = NULL;
-          return retval;
+          goto err;
         }
 
         s_token = strtok_r(NULL, ":", &saveptr);
@@ -147,11 +135,7 @@ int get_devices_from_authfile(const char *authfile, const char *username,
         if (!s_token) {
           if (verbose)
             D(("Unable to retrieve publicKey number %d", i + 1));
-          *n_devs = 0;
-          fclose(opwfile);
-          free(buf);
-          buf = NULL;
-          return retval;
+          goto err;
         }
 
         if (verbose)
@@ -160,11 +144,7 @@ int get_devices_from_authfile(const char *authfile, const char *username,
         if (strlen(s_token) % 2 != 0) {
           if (verbose)
             D(("Length of key number %d not even", i + 1));
-          *n_devs = 0;
-          fclose(opwfile);
-          free(buf);
-          buf = NULL;
-          return retval;
+          goto err;
         }
 
         devices[i].key_len = strlen(s_token) / 2;
@@ -178,12 +158,7 @@ int get_devices_from_authfile(const char *authfile, const char *username,
         if (!devices[i].publicKey) {
           if (verbose)
             D(("Unable to allocate memory for publicKey number %d", i));
-
-          *n_devs = 0;
-          fclose(opwfile);
-          free(buf);
-          buf = NULL;
-          return retval;
+          goto err;
         }
 
         for (j = 0; j < devices[i].key_len; j++) {
@@ -191,11 +166,7 @@ int get_devices_from_authfile(const char *authfile, const char *username,
           if (sscanf(&s_token[2 * j], "%2x", &x) != 1) {
             if (verbose)
               D(("Invalid hex number in key"));
-            *n_devs = 0;
-            fclose(opwfile);
-            free(buf);
-            buf = NULL;
-            return retval;
+            goto err;
           }
           devices[i].publicKey[j] = (char)x;
         }
@@ -204,15 +175,23 @@ int get_devices_from_authfile(const char *authfile, const char *username,
       }
     }
   }
-  fclose(opwfile);
 
   if (verbose)
     D(("Found %d device(s) for user %s", *n_devs, username));
 
+  retval = 1;
+  goto out;
+
+err:
+  *n_devs = 0;
+
+out:
   free(buf);
   buf = NULL;
-
-  retval = 1;
+  if (opwfile)
+    fclose(opwfile);
+  else if (fd >= 0)
+    close(fd);
   return retval;
 }
 

--- a/util.c
+++ b/util.c
@@ -31,6 +31,9 @@ int get_devices_from_authfile(const char *authfile, const char *username,
   FILE *opwfile;
   unsigned i, j;
 
+  /* Ensure we never return uninitialized count. */
+  *n_devs = 0;
+
   fd = open(authfile, O_RDONLY, 0);
   if (fd < 0) {
     if (verbose)

--- a/util.c
+++ b/util.c
@@ -184,8 +184,9 @@ int get_devices_from_authfile(const char *authfile, const char *username,
         }
 
         for (j = 0; j < devices[i].key_len; j++) {
-          sscanf(&s_token[2 * j], "%2x",
-                 (unsigned int *)&(devices[i].publicKey[j]));
+          unsigned int x;
+          sscanf(&s_token[2 * j], "%2x", &x);
+          devices[i].publicKey[j] = (char)x;
         }
 
         i++;


### PR DESCRIPTION
Hello,

While deploying pam-u2f we looked at get_devices_from_authfile() which handles untrusted data (with the default authfile setting users control the file) and noticed several issues. With the help of AFL we identified invalid memory access and memory leaks. This patch sets fixes these issues and performs a minor code cleanup for the error handling.

Due to lack of experience we didn't fuzz the USB part of the code which also handles untrusted input, but we think it would be a good way to further harden pam-u2f.

Regards
Simon