### PR TITLE
Fixes syslog crash in some applications

### DIFF
--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -68,7 +68,6 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t *cfg) {
         cfg->debug_file = stderr;
       }
       else if( strncmp (filename, "syslog", 6) == 0) {
-        openlog("pam_u2f.so", LOG_NDELAY|LOG_PID, LOG_AUTHPRIV);
         cfg->debug_file = (FILE *)-1;
       }
       else {

--- a/util.c
+++ b/util.c
@@ -537,7 +537,7 @@ void _debug( FILE *debug_file, const char *file, int line, const char *func, con
   va_end(ap);
 
   if (debug_file == (FILE *)-1) {
-    syslog(LOG_DEBUG, "%s", out);
+    syslog(LOG_AUTHPRIV|LOG_DEBUG, "%s", out);
   }
   else {
     fprintf(debug_file, "%s\n", out);

--- a/util.c
+++ b/util.c
@@ -543,7 +543,7 @@ void _debug( FILE *debug_file, const char *file, int line, const char *func, con
     fprintf(debug_file, "%s\n", out);
   }
 
-  if (size >= (BUFSIZE - 1)) {
+  if ( out != buffer ) {
     free(out);
   }
 #else /* Windows, MAC */

--- a/util.h
+++ b/util.h
@@ -18,7 +18,7 @@
 #define DEFAULT_AUTHFILE "/Yubico/u2f_keys"
 #define DEFAULT_PROMPT "Insert your U2F device, then press ENTER."
 #define DEFAULT_ORIGIN_PREFIX "pam://"
-#define DEBUG_STR "debug: %s:%d (%s): "
+#define DEBUG_STR "debug(pam_u2f): %s:%d (%s): "
 
 #if defined(DEBUG_PAM)
 #define D(file, ...)  _debug(file, __FILE__, __LINE__, __func__, __VA_ARGS__)


### PR DESCRIPTION
Apparently I created a bug causing a segfault in applications that already have syslog opened, which many that do authentication will have, if dumping debug to syslog as well--I'm not sure exactly where it comes from, but my hunch is that the address of the string constant goes out of scope when the .so is unloaded.