### PR TITLE
Avoid cueing user if no suitable U2F device is available.

### DIFF
--- a/util.h
+++ b/util.h
@@ -17,6 +17,7 @@
 #define DEFAULT_AUTHFILE_DIR_VAR "XDG_CONFIG_HOME"
 #define DEFAULT_AUTHFILE "/Yubico/u2f_keys"
 #define DEFAULT_PROMPT "Insert your U2F device, then press ENTER."
+#define DEFAULT_CUE "Please touch the device."
 #define DEFAULT_ORIGIN_PREFIX "pam://"
 #define DEBUG_STR "debug: %s:%d (%s): "
 


### PR DESCRIPTION
The original code would emit the "Please touch the device," string if configured by the cue command if any U2F token was inserted instead of doing so only upon finding a U2F token that is actually configured in the system. It does so by coercing the libu2f-host library to send a "check-only" authentication request to the attached tokens (0x7 control byte of this[0] spec).

In the PAM mantra of, "the user should know nothing about which module failed," emitting this message early leaks information about the system. Admittedly, the delay introduced with the extra interrogation also leaks information, and a malicious u2f key could record the keyhandle for off-line interrogation of keys, but at the very least, this avoids confusing users by not emitting the cue if no suitable key is inserted.

[0] - https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html