### PR TITLE
Signify that pam-u2f is waiting for a touch

### DIFF
--- a/README
+++ b/README
@@ -95,6 +95,14 @@ file is $XDG_CONFIG_HOME/Yubico/u2f_keys. If the environment variable
 is not set, $HOME/.config/Yubico/u2f_keys is used.
 (more on <<files,Authorization Mapping Files>>).
 
+authpending_file=file::
+Set the location of the file that is used for touch request notifications.
+This file will be opened when pam-u2f starts waiting for a user to touch the device,
+and will be closed when it no longer waits for a touch.
+Use inotify to listen on these events, or a more high-level tool like https://github.com/maximbaz/yubikey-touch-detector[yubikey-touch-detector].
+Set an empty value in order to disable this functionality, like so: `authpending_file=`.
+Default value: /var/run/user/$UID/pam-u2f-authpending
+
 nouserok::
 Set to enable authentication attempts to succeed even if the user trying to
 authenticate is not found inside authfile or if authfile is missing/malformed.

--- a/man/pam_u2f.8.txt
+++ b/man/pam_u2f.8.txt
@@ -29,6 +29,9 @@ Set the application ID for the U2F authentication procedure. If no value is spec
 *authfile*=_file_::
 Set the location of the file that holds the mappings of user names to keyHandles and user keys. The format is username:keyHandle1,public_key1:keyHandle2,public_key2:... the default location of the file is $XDG_CONFIG_HOME/Yubico/u2f_keys. If the environment variable is not set, $HOME/.config/Yubico/u2f_keys is used.
 
+*authpending_file*=_file_::
+Set the location of the file that is used for touch request notifications. This file will be opened when pam-u2f starts waiting for a user to touch the device, and will be closed when it no longer waits for a touch. Use inotify to listen on these events, or a more high-level tool like yubikey-touch-detector. Default value: /var/run/user/$UID/pam-u2f-authpending. Set an empty value in order to disable this functionality, like so: lockfile=
+
 *nouserok*::
 Set to enable authentication attempts to succeed even if the user trying to authenticate is not found inside authfile or if authfile is missing/malformed.
 

--- a/util.h
+++ b/util.h
@@ -16,6 +16,7 @@
 #define DEVSIZE (((PK_LEN) + (KH_LEN) + (RD_LEN)))
 #define DEFAULT_AUTHFILE_DIR_VAR "XDG_CONFIG_HOME"
 #define DEFAULT_AUTHFILE "/Yubico/u2f_keys"
+#define DEFAULT_AUTHPENDING_FILE_PATH "/var/run/user/%d/pam-u2f-authpending"
 #define DEFAULT_PROMPT "Insert your U2F device, then press ENTER."
 #define DEFAULT_CUE "Please touch the device."
 #define DEFAULT_ORIGIN_PREFIX "pam://"
@@ -38,6 +39,7 @@ typedef struct {
   int interactive;
   int cue;
   const char *auth_file;
+  char *authpending_file;
   const char *origin;
   const char *appid;
   const char *prompt;


### PR DESCRIPTION
Feedback on the code is very welcome!

This code has one functional issue where I hope you could give me a hint. I'll explain the scenario:

1. Open terminal 1, type `sudo -s`, do not touch the device.
    * "Please touch the device" appears and stays on the screen as expected.
    * The marker file is created as expected.
2. Open terminal 2, type `sudo -s`, do not touch the device.
    * "Please touch the device" appears and stays on the screen as expected.
    * On the terminal 1, the wait for touch is cancelled, I see a password prompt there - as expected.
    * The marker file does not exist - **not expected**.

This is a race condition, in two terminals the code has reached the line where I create a marker file, but as soon as the first terminal aborts its waiting, it removes the file without accounting for the fact that there is a second terminal that is also waiting for a touch.

I tried to play with `flock()` with a hope that if a process locks a file, another process would not be able to remove it... but that doesn't seem to be the case.

My other ideas include:
- Store a counter in the lock file.
- Create files with random suffix and put them in `/var/run/user/1000/pam-u2f-lock/` folder, in which case the presence of _at least one file_ indicates that pam-u2f is waiting for a touch.

Your suggestions?

**UPDATE:**

One more idea: 

- Keep the file exist forever, only "touch" it before and after authentication (just open and close) - this will be enough for me when using inotify, but may not be as nice for others.

And one more problem: I am unable to setup a file system event watcher on a file that doesn't exist yet, I have to set it on something that exists... We could have used something like `/var/run/user/1000/pam-u2f/lock` and only create/remove the `lock` file while keeping the folder available, but how can we ensure that the folder exists after installation of pam-u2f?