### PR TITLE
Adds "nodetect" option to skip detection of suitable key

### DIFF
--- a/README
+++ b/README
@@ -136,6 +136,17 @@ If enabled, interactive mode becomes redundant and has no effect.
 cue::
 Set to prompt a message to remind to touch the device.
 
+nodetect::
+Set to skip detecting if a suitable U2F token is inserted before performing
+the full tactile authentication. This detection was created to avoid
+emitting the "cue" message if no suitable token exists, because doing so
+leaks information about the authentication stack if a token is inserted but
+not configured for the authenticating user. However, it was found that
+versions of libu2f-user 1.1.5 or less has buggy iteration/sleep behavior
+which causes a 1-second delay to occur for this initial detection. For this
+reason, as well as the possibility of hypothetical tokens that do not
+tolerate this double authentication, the "nodetect" option was added.
+
 [[files]]
 Authorization Mapping Files
 ---------------------------

--- a/man/pam_u2f.8.txt
+++ b/man/pam_u2f.8.txt
@@ -58,6 +58,9 @@ Set to drop to a manual console where challenges are printed on screen and respo
 *cue*::
 Set to prompt a message to remind to touch the device.
 
+*nodetect*::
+Skip detecting if a suitable key is inserted before performing a full authentication. See *NOTES* below.
+
 == EXAMPLES
 
 auth sufficient pam_u2f.so debug origin=pam://$HOSTNAME appid=pam://$HOSTNAME
@@ -69,6 +72,36 @@ Using pam-u2f to secure the login to a computer while
 storing the mapping file in an encrypted home directory, will result
 in the impossibility of logging into the system. The partition is
 decrypted after login and the mapping file can not be accessed.
+
+== NOTES
+The "nodetect" option should be used with caution. pam_u2f checks that a
+key configured for the user is inserted before performing the full tactile
+authentication. This detection is done by sending a "check-only"
+authentication request to all inserted tokens to so see if at least one of
+them responds affirmatively to one or more of the keyhandles configured for
+the user. By doing this, pam_u2f can avoid emitting the "cue" prompt (if
+configured), which can cause some confusing UI issues if the cue is emitted
+followed by the underlying library immediately failing the tactile
+authentication. This option is also useful to avoid an unintended 1-second
+delay prior to the tactile authentication caused by versions of libu2f-host
+\<= 1.1.5.
+
+If pam_u2f is configured to "cue" and "nodetect", an attacker can determine
+that pam_u2f is part of the authentication stack by inserting any random
+U2F token and performing an authentication attempt. In this scenario, the
+attacker would see the cue message followed by an immediate failure,
+whereas with detection enabled, the U2F authentication will fail silently.
+Understand that an attacker could choose a U2F token that alerts him or
+her in some way to the "check-only" authentication attempt, so this
+precaution only pushes the issue back a step.
+
+In summary, the detection feature was added to avoid confusing UI issues
+and to prevent leaking information about the authentication stack in very
+specific scenario when "cue" is configured. The "nodetect" option was added
+to avoid buggy sleep behavior in older versions of libu2f-host and for
+hypothetical tokens that do not tolerate the double authentication.
+Detection is performed, and likewise "nodetect" honored, regardless of
+whether "cue" is also specified.
 
 == BUGS
 Report pam-u2f bugs in the issue tracker: https://github.com/Yubico/pam-u2f/issues

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -52,6 +52,8 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t *cfg) {
       cfg->interactive = 1;
     if (strcmp(argv[i], "cue") == 0)
       cfg->cue = 1;
+    if (strcmp(argv[i], "nodetect") == 0)
+      cfg->nodetect = 1;
     if (strncmp(argv[i], "authfile=", 9) == 0)
       cfg->auth_file = argv[i] + 9;
     if (strncmp(argv[i], "authpending_file=", 17) == 0)
@@ -98,6 +100,7 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t *cfg) {
     D(cfg->debug_file, "debug=%d", cfg->debug);
     D(cfg->debug_file, "interactive=%d", cfg->interactive);
     D(cfg->debug_file, "cue=%d", cfg->cue);
+    D(cfg->debug_file, "nodetect=%d", cfg->nodetect);
     D(cfg->debug_file, "manual=%d", cfg->manual);
     D(cfg->debug_file, "nouserok=%d", cfg->nouserok);
     D(cfg->debug_file, "openasuser=%d", cfg->openasuser);

--- a/util.c
+++ b/util.c
@@ -326,7 +326,10 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
     if (cfg->debug)
       D(cfg->debug_file, "Challenge: %s", buf);
 
-    if ((h_rc = u2fh_authenticate(devs, buf, cfg->origin, &response, 0)) == U2FH_OK ) {
+    if (cfg->nodetect || (h_rc = u2fh_authenticate(devs, buf, cfg->origin, &response, 0)) == U2FH_OK ) {
+
+      if (cfg->nodetect)
+        D(cfg->debug_file, "nodetect option specified, suitable key detection skipped");
 
       if (cfg->manual == 0 && cfg->cue && !cued) {
         cued = 1;

--- a/util.h
+++ b/util.h
@@ -38,6 +38,7 @@ typedef struct {
   int alwaysok;
   int interactive;
   int cue;
+  int nodetect;
   const char *auth_file;
   const char *authpending_file;
   const char *origin;


### PR DESCRIPTION
This is just like your `safecue` but fully documented and explained, and separated entirely from the `cue` option.