### PR TITLE
Switch to using vsyslog/vfprintf in the linux case as well

### DIFF
--- a/util.c
+++ b/util.c
@@ -1117,50 +1117,23 @@ char *converse(pam_handle_t *pamh, int echocode, const char *prompt) {
 #if defined(PAM_DEBUG)
 void _debug(FILE *debug_file, const char *file, int line, const char *func, const char *fmt, ...) {
   va_list ap;
+  va_start(ap, fmt);
 #ifdef __linux__
-  unsigned int size;
-  char buffer[BUFSIZE];
-  char *out;
-
-  size = (unsigned int)snprintf(NULL, 0, DEBUG_STR, file, line, func);
-  va_start(ap, fmt);
-  size += (unsigned int)vsnprintf(NULL, 0, fmt, ap);
-  va_end(ap);
-  va_start(ap, fmt);
-  if (size < (BUFSIZE - 1)) {
-    out = buffer;
-  }
-  else {
-    out = malloc(size);
-  }
-
-  if (out) {
-    size = (unsigned int)sprintf(out, DEBUG_STR, file, line, func);
-    vsprintf(&out[size], fmt, ap);
-    va_end(ap);
-  }
-  else {
-    out = buffer;
-    sprintf(out, "debug(pam_u2f): malloc failed when trying to log\n");
-  }
-
   if (debug_file == (FILE *)-1) {
-    syslog(LOG_AUTHPRIV | LOG_DEBUG, "%s", out);
+    syslog(LOG_AUTHPRIV | LOG_DEBUG, DEBUG_STR, file, line, func);
+    vsyslog(LOG_AUTHPRIV | LOG_DEBUG, fmt, ap);
   }
   else {
-    fprintf(debug_file, "%s\n", out);
-  }
-
-  if (out != buffer) {
-    free(out);
+    fprintf(debug_file, DEBUG_STR, file, line, func);
+    vfprintf(debug_file, fmt, ap);
+    fprintf(debug_file, "\n");
   }
 #else /* Windows, MAC */
-  va_start(ap, fmt);
   fprintf(debug_file, DEBUG_STR, file, line, func );
   vfprintf(debug_file, fmt, ap);
   fprintf(debug_file, "\n");
-  va_end(ap);
 #endif /* __linux__ */
+  va_end(ap);
 }
 #endif /* PAM_DEBUG */
 


### PR DESCRIPTION
Fixes a one byte heap overwrite if called with a large buffer.

Consider the follow scenario:

size = (unsigned int)snprintf(NULL, 0, DEBUG_STR, file, line, func);
va_start(ap, fmt);
size += (unsigned int)vsnprintf(NULL, 0, fmt, ap);

Size now contains length but without counting the \0

    out = malloc(size);

No room allocated for the terminating \0

 if (out) {
    size = (unsigned int)sprintf(out, DEBUG_STR, file, line, func);
    vsprintf(&out[size], fmt, ap);
    va_end(ap);
 }

vsprintf will terminate the out buffer with a \0 outside of the allocated area.

Tested on Linux with debug set to stderr, a file and syslog