### PR TITLE
DBG mode: debug_file missing

### DIFF
--- a/README
+++ b/README
@@ -204,9 +204,12 @@ users should not rely on the default origin and appid ("pam://$HOSTNAME")
 but set those parameters explicitly to the same value.
 
 == Individual authorization mapping by user
-Each user creates a `~/.config/Yubico/u2f_keys` file inside of their home
-directory and places the mapping in that file, the file must have only one
-line:
+Each user creates a `.config/Yubico/u2f_keys` (default) file inside their 
+home directory and places the mapping in that file. You may want to specify 
+a different per user file (relative to the user's home dir), i.e. 
+`.ssh/u2f_keys`.
+
+The file must have only one line:
 
  <username>:<KeyHandle1>,<UserKey1>:<KeyHandle2>,<UserKey2>:...
 

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -280,8 +280,8 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
     buf = NULL;
   } else {
     if (cfg->auth_file[0] != '/') {
-	    /* Individual authorization mapping by user: auth_file is not
-                absolute path, so prepend user home dir. */
+      /* Individual authorization mapping by user: auth_file is not
+          absolute path, so prepend user home dir. */
       openasuser = geteuid() == 0 ? 1 : 0;
 
       authfile_dir_len =

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -279,10 +279,13 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
     should_free_auth_file = 1;
     buf = NULL;
   } else {
-    if (strncmp(cfg->auth_file, "/", 1) != 0) { /* Individual authorization mapping by user: auth_file is not absolute path, so prepend user home dir. */
+    if (strncmp(cfg->auth_file, "/", 1) != 0) {
+	    /* Individual authorization mapping by user: auth_file is not
+                absolute path, so prepend user home dir. */
       openasuser = geteuid() == 0 ? 1 : 0;
 
-      authfile_dir_len = strlen(pw->pw_dir) + strlen("/") + strlen(cfg->auth_file) + 1;
+      authfile_dir_len =
+        strlen(pw->pw_dir) + strlen("/") + strlen(cfg->auth_file) + 1;
       buf = malloc(sizeof(char) * (authfile_dir_len));
 
       if (!buf) {
@@ -294,7 +297,7 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
       snprintf(buf, authfile_dir_len, "%s/%s", pw->pw_dir, cfg->auth_file);
 
       cfg->auth_file = buf; /* update cfg */
-      should_free_auth_file = 1;   
+      should_free_auth_file = 1;
       buf = NULL;
     }
 

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -279,7 +279,7 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
     should_free_auth_file = 1;
     buf = NULL;
   } else {
-    if (strncmp(cfg->auth_file, "/", 1) != 0) {
+    if (cfg->auth_file[0] != '/') {
 	    /* Individual authorization mapping by user: auth_file is not
                 absolute path, so prepend user home dir. */
       openasuser = geteuid() == 0 ? 1 : 0;


### PR DESCRIPTION
When a debug_file is specified but not yet created pam-u2f would not create and not log to the debug_file consequently. Amend this.