### PR TITLE
Add fuzzing harness for fuzzing native and ssh formats

### DIFF
--- a/.github/workflows/linux_fuzz.yml
+++ b/.github/workflows/linux_fuzz.yml
@@ -1,0 +1,29 @@
+name: fuzzer
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        cc: [clang-10]
+        sanitizer: [asan]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Dependencies
+      env:
+        CC: ${{ matrix.cc }}
+      run: |
+        sudo apt -q update
+        sudo apt install -q -y autoconf automake libtool pkg-config \
+          libfido2-dev libpam-dev gengetopt
+          sudo apt install -q -y ${CC%-*}-tools-${CC#clang-}
+    - name: Fuzz
+      env:
+        CC: ${{ matrix.cc }}
+        SANITIZER: ${{ matrix.sanitizer }}
+      run: |
+        /bin/sh -eux build-aux/ci/fuzz-linux-${SANITIZER}.sh

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ pamu2fcfg/cmdline.h
 pamu2fcfg/pamu2fcfg
 man/pamu2fcfg.1
 tests/get_devices
+fuzz/Makefile
+fuzz/fuzz_format_parsers

--- a/build-aux/ci/fuzz-linux-asan.sh
+++ b/build-aux/ci/fuzz-linux-asan.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -eux
+
+${CC} --version
+
+./autogen.sh
+./configure --disable-silent-rules --disable-man CFLAGS="-fsanitize=address,signed-integer-overflow"
+make
+make -C fuzz
+
+curl --retry 4 -s -o corpus.tgz https://storage.googleapis.com/kroppkaka/corpus/pam-u2f.corpus.tgz
+tar xzf corpus.tgz
+fuzz/fuzz_format_parsers -reload=30 -print_pcs=1  -print_funcs=30 -timeout=10 -runs=1 corpus
+
+

--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,20 @@ AS_IF([test "$enable_man" = "yes"],
 )
 AM_CONDITIONAL([ENABLE_MAN], [test "$enable_man" = "yes"])
 
+AC_CACHE_CHECK([for clang],
+        _cv_clang,[
+        AC_TRY_COMPILE([], [
+                #ifdef __clang__
+                #else
+                #error "NOT CLANG"
+                #endif
+                return 0;
+        ],
+        [_cv_clang=yes],
+        [_cv_clang=no],
+        [])
+])
+AM_CONDITIONAL([COMPILER_CLANG], [test "$_cv_clang" = yes])
 
 AC_CHECK_HEADERS([security/pam_appl.h], [],
   [AC_MSG_ERROR([[PAM header files not found, install libpam-dev.]])])
@@ -135,6 +149,10 @@ AC_CONFIG_FILES([tests/credentials/new_-V.cred])
 AC_CONFIG_FILES([tests/credentials/old_credential.cred])
 AC_CONFIG_FILES([tests/credentials/ssh_credential.cred])
 
+# Are we running with clang
+if test "$_cv_clang" = "yes"; then
+   AC_CONFIG_FILES([fuzz/Makefile])
+fi
 AC_OUTPUT
 
 

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,0 +1,14 @@
+# Copyright (C) 2020 Yubico AB - See COPYING
+
+AM_CFLAG = ${(WARN_FLAGS)
+AM_CPPFLAGS = $(LIBFIDO2_CFLAGS) $(LIBCRYPTO_CFLAGS) -I$(srcdir)/..
+AM_CPPFLAGS+=-fsanitize=fuzzer,address,signed-integer-overflow 
+AM_CPPFLAGS+=-fno-sanitize-recover=all
+
+fuzz_format_parsers_SOURCES = fuzz_format_parsers.c
+
+fuzz_format_parsers_LDADD = -lpam $(LIBFIDO2_LIBS) $(LIBCRYPTO_LIBS)
+fuzz_format_parsers_LDFLAGS = -Wl,--wrap=strdup -Wl,--wrap=calloc
+fuzz_format_parsers_LDFLAGS+= -fsanitize=fuzzer,address,signed-integer-overflow
+
+bin_PROGRAMS = fuzz_format_parsers

--- a/fuzz/coverage.sh
+++ b/fuzz/coverage.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -eux
+
+make CFLAGS="-fprofile-instr-generate -fcoverage-mapping" V=1
+if [ ! -e "corpus" ]; then
+    curl --retry 4 -s -o corpus.tgz https://storage.googleapis.com/kroppkaka/corpus/pam-u2f.corpus.tgz
+    tar xzf corpus.tgz
+fi
+./fuzz_format_parsers -runs=1 -dump_coverage=1 corpus
+llvm-profdata merge -sparse *.profraw -o default.profdata
+llvm-cov report -show-functions -instr-profile=default.profdata fuzz_format_parsers ../*.c
+
+# other report alternatives for convenience:
+#llvm-cov report -use-color=false -instr-profile=default.profdata fuzz_format_parsers
+#llvm-cov show -format=html -tab-size=8 -instr-profile=default.profdata -output-dir=report fuzz_format_parsers
+#llvm-cov show fuzz_format_parsers -instr-profile=default.profdata -name=format -format=html > report.html

--- a/fuzz/fuzz_format_parsers.c
+++ b/fuzz/fuzz_format_parsers.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2020 Yubico AB - See COPYING
+ */
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "util.c"
+#include "b64.c"
+
+/* wrap some functions so we can let them fail some times to trigger error
+ * paths. compile with -Wl,--wrap=strdup -Wl,--wrap=calloc to activate.
+ * Note: idea taken from libfido2/fuzz/wrap.c
+ */
+extern char *__wrap_strdup(const char *);
+extern char *__real_strdup(const char *);
+char *__wrap_strdup(const char *s) {
+  if (random() < (RAND_MAX / 100) / 4) { // fail 0.25% of the time
+    errno = ENOMEM;
+    return NULL;
+  }
+
+  return __real_strdup(s);
+}
+
+extern void *__wrap_calloc(size_t, size_t);
+extern void *__real_calloc(size_t, size_t);
+void *__wrap_calloc(size_t nmemb, size_t size) {
+  if (random() < (RAND_MAX / 100) / 4) { // fail 0.25% of the time
+    errno = ENOMEM;
+    return NULL;
+  }
+
+  return __real_calloc(nmemb, size);
+}
+
+static void cleanup(device_t *devs, unsigned int n_devs) {
+  for (int i = 0; i < n_devs; i++) {
+    free(devs[i].keyHandle);
+    free(devs[i].publicKey);
+    free(devs[i].coseType);
+    free(devs[i].attributes);
+    devs[i].keyHandle = NULL;
+    devs[i].publicKey = NULL;
+    devs[i].coseType = NULL;
+    devs[i].attributes = NULL;
+  }
+}
+
+#define DEV_MAX_SIZE 10
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  char buf[DEVSIZE * DEV_MAX_SIZE]; /* DEVSIZE * cfg.max_size */
+  device_t devs[12] = {0};
+  unsigned int n_devs = 12;
+  FILE *fp = NULL;
+  size_t fp_len = 0;
+  size_t offset = 0;
+  char username[256] = {0};
+  size_t username_len = 0;
+  uint8_t ssh_format = 1;
+  cfg_t cfg = {0};
+  cfg.max_devs = DEV_MAX_SIZE;
+
+  /* first 6 byte decides which parser we should call, if
+   * we want to run with debug and also sets the initial seed
+   * for random().
+   */
+  if (size < 6) {
+    return -1;
+  }
+  /* do not always run with debug, only 8/255 times */
+  if (data[offset++] < 9) {
+    cfg.debug = 1;
+  }
+
+  /* predictable random for this seed */
+  srandom(data[offset] << 24 | data[offset + 1] << 16 | data[offset + 2] << 8 |
+          data[offset + 3]);
+  offset += 4;
+
+  /* choose which format parser to run, even == native, odd == ssh */
+  if (data[offset++] % 2) {
+    ssh_format = 0;
+    /* native format, get a random username first */
+    if (size < 7) {
+      return -1;
+    }
+    username_len = data[offset++];
+    if (username_len > (size - offset)) {
+      username_len = (size - offset);
+    }
+    memcpy(username, &data[offset], username_len);
+    offset += username_len;
+  }
+
+  fp_len = size - offset;
+  fp = tmpfile();
+  if (fp == NULL || (fwrite(&data[offset], 1, fp_len, fp)) != fp_len) {
+    fprintf(stderr, "failed to create file for parser: %s\n", strerror(errno));
+    if (fp != NULL) {
+      fclose(fp);
+    }
+    return -1;
+  }
+  (void) fseek(fp, 0L, SEEK_SET);
+
+  if (ssh_format) {
+    parse_ssh_format(&cfg, buf, sizeof(buf), fp, size, devs, &n_devs);
+  } else {
+    parse_native_format(&cfg, username, buf, fp, devs, &n_devs);
+  }
+
+  cleanup(devs, n_devs);
+
+  fclose(fp);
+
+  return 0;
+}

--- a/fuzz/make_seed.py
+++ b/fuzz/make_seed.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# append the 1 byte the fuzzer needs to decide which format to choose,
+# 1 byte for debug or not and then 4 bytes for the srandom() seed.
+# run this script and then merge the generated seeds to the corpus.
+# Note: this has already been done with the existing corpus. This
+# script is included in case new credentials tests are added
+# ./make_seed.py
+# ./fuzz_format_parsers corpus seed -merge=1
+
+import os
+
+if not os.path.exists("./seed"):
+    os.mkdir("./seed")
+
+with os.scandir("../tests/credentials") as entries:
+    for entry in entries:
+        if not entry.is_file():
+            continue
+        print(entry.name)
+        with open("./seed/{}".format(entry.name), "wb") as w:
+            w.write(bytes([1,1,1,1,1,1]))
+            with open("../tests/credentials/{}".format(entry.name), "rb") as r:
+                w.write(r.read())
+        with open("./seed/{}.ssh".format(entry.name), "wb") as w:
+            w.write(bytes([0,1,1,1,1,1]))
+            with open("../tests/credentials/{}".format(entry.name), "rb") as r:
+                w.write(r.read())


### PR DESCRIPTION
With this harness we get good coverage in the format parsing code.

The fuzzer will also run on every push and pull request, using the corpus I have generated and stored in a google cloud bucket which exercises most code paths in the format parsers.  Further harnesses can be added later to get more coverage.

Do you think this can be added to the repo?

```
$ llvm-cov report -show-functions -instr-profile=default.profdata fuzz_format_parsers ../*.c
File '/user/kode/pam-u2f/b64.c':
Name                        Regions    Miss   Cover     Lines    Miss   Cover
-----------------------------------------------------------------------------
b64_encode                       33       5  84.85%        48       2  95.83%
b64_decode                       27       4  85.19%        48       1  97.92%
-----------------------------------------------------------------------------
TOTAL                            60       9  85.00%        96       3  96.88%

File '/user/kode/pam-u2f/util.c':
Name                                                Regions    Miss   Cover     Lines    Miss   Cover
-----------------------------------------------------------------------------------------------------
get_devices_from_authfile                                75      75   0.00%       124     124   0.00%
free_devices                                              7       7   0.00%        23      23   0.00%
do_authentication                                       225     225   0.00%       339     339   0.00%
do_manual_authentication                                159     159   0.00%       288     288   0.00%
converse                                                 20      20   0.00%        28      28   0.00%
random_bytes                                             10      10   0.00%        15      15   0.00%
fuzz_format_parsers.c:parse_native_format               108       0 100.00%       183       0 100.00%
fuzz_format_parsers.c:normal_b64                         16       1  93.75%        40       1  97.50%
fuzz_format_parsers.c:parse_ssh_format                  415       0 100.00%       580       0 100.00%
fuzz_format_parsers.c:hex_decode                         20      20   0.00%        28      28   0.00%
fuzz_format_parsers.c:translate_old_format_pubkey        25      25   0.00%        31      31   0.00%
fuzz_format_parsers.c:get_authenticators                 51      51   0.00%        68      68   0.00%
fuzz_format_parsers.c:_converse                           4       4   0.00%        12      12   0.00%
-----------------------------------------------------------------------------------------------------
TOTAL                                                  1135     597  47.40%      1759     957  45.59%
```
