### PR TITLE
b64,util: always include limits.h

### DIFF
--- a/b64.c
+++ b/b64.c
@@ -4,6 +4,7 @@
 
 #include <openssl/bio.h>
 #include <openssl/evp.h>
+#include <limits.h>
 #include <stdint.h>
 #include <string.h>
 

--- a/util.c
+++ b/util.c
@@ -9,6 +9,7 @@
 #include <openssl/ec.h>
 #include <openssl/obj_mac.h>
 
+#include <limits.h>
 #include <stdlib.h>
 #include <fcntl.h>
 #include <sys/stat.h>


### PR DESCRIPTION
UCHAR_MAX and INT_MAX are defined within limits.h

Current codebase failed to be built in Linux with musl libc due to
missing this inclusion.

Fix it.