### PR TITLE
actions: add xsltproc as dependency

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,7 +9,7 @@ on:
 env:
   SCAN_IMG:
     yubico-yes-docker-local.jfrog.io/static-code-analysis/c:v1
-  COMPILE_DEPS: "libfido2-dev"
+  COMPILE_DEPS: "libfido2-dev xsltproc"
   SECRET: ${{ secrets.ARTIFACTORY_READER_TOKEN }}
 
 jobs:


### PR DESCRIPTION
Seems Github images dropped this by default so we now need to explicitly install it.