### PR TITLE
Support self-attestation in pamu2fcfg

### DIFF
--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -285,10 +285,18 @@ int main(int argc, char *argv[]) {
     exit(EXIT_FAILURE);
   }
 
-  r = fido_cred_verify(cred);
-  if (r != FIDO_OK) {
-    fprintf(stderr, "error: fido_cred_verify (%d) %s\n", r, fido_strerr(r));
-    exit(EXIT_FAILURE);
+  if (fido_cred_x5c_ptr(cred) == NULL) {
+    r = fido_cred_verify_self(cred);
+    if (r != FIDO_OK) {
+      fprintf(stderr, "error: fido_cred_verify_self (%d) %s\n", r, fido_strerr(r));
+      exit(EXIT_FAILURE);
+    }
+  } else {
+    r = fido_cred_verify(cred);
+    if (r != FIDO_OK) {
+      fprintf(stderr, "error: fido_cred_verify (%d) %s\n", r, fido_strerr(r));
+      exit(EXIT_FAILURE);
+    }
   }
 
   kh = fido_cred_id_ptr(cred);


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/1366. Tested by @prusnak.

This PR adds support for [self attestation](https://www.w3.org/TR/webauthn/#self-attestation) in pamu2fcfg, which was implemented in libfido2 about a year ago (v1.3.0) as a result of https://github.com/Yubico/libfido2/issues/57.