### PR TITLE
Fix for #175 + related fix

### DIFF
--- a/util.c
+++ b/util.c
@@ -1379,8 +1379,13 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
           goto out;
         }
 
-        if (pin_verification == FIDO_OPT_TRUE)
+        if (pin_verification == FIDO_OPT_TRUE) {
           pin = converse(pamh, PAM_PROMPT_ECHO_OFF, "Please enter the PIN: ");
+          if (pin == NULL) {
+            D(cfg->debug_file, "converse() returned NULL");
+            goto out;
+          }
+        }
         if (user_presence == FIDO_OPT_TRUE ||
             user_verification == FIDO_OPT_TRUE) {
           if (cfg->manual == 0 && cfg->cue && !cued) {

--- a/util.c
+++ b/util.c
@@ -1401,6 +1401,14 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
           pin = NULL;
         }
         if (r == FIDO_OK) {
+          if (pin_verification == FIDO_OPT_TRUE ||
+              user_verification == FIDO_OPT_TRUE) {
+            r = fido_assert_set_uv(assert, FIDO_OPT_TRUE);
+            if (r != FIDO_OK) {
+              D(cfg->debug_file, "Failed to set UV");
+              goto out;
+            }
+          }
           r = fido_assert_verify(assert, 0, cose_type,
                                  cose_type == COSE_ES256
                                    ? (const void *) es256_pk


### PR DESCRIPTION
- Handle converse() returning NULL;
- Check that the UV bit is set in fido_assert_verify().