### PR TITLE
dist: make tarball configure/build with CC=clang 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,10 @@
 
 SUBDIRS = . pamu2fcfg tests
 
+if COMPILER_CLANG
+SUBDIRS += fuzz
+endif
+
 ACLOCAL_AMFLAGS = -I m4
 
 AM_CFLAGS = $(CWFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,7 @@ AC_CONFIG_FILES([
   Makefile
   pamu2fcfg/Makefile
   tests/Makefile
+  fuzz/Makefile
 ])
 
 creduser=$(whoami)
@@ -148,11 +149,6 @@ AC_CONFIG_FILES([tests/credentials/new_-V-N.cred])
 AC_CONFIG_FILES([tests/credentials/new_-V.cred])
 AC_CONFIG_FILES([tests/credentials/old_credential.cred])
 AC_CONFIG_FILES([tests/credentials/ssh_credential.cred])
-
-# Are we running with clang
-if test "$_cv_clang" = "yes"; then
-   AC_CONFIG_FILES([fuzz/Makefile])
-fi
 AC_OUTPUT
 
 

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -12,3 +12,5 @@ fuzz_format_parsers_LDFLAGS = -Wl,--wrap=strdup -Wl,--wrap=calloc
 fuzz_format_parsers_LDFLAGS+= -fsanitize=fuzzer,address,signed-integer-overflow
 
 bin_PROGRAMS = fuzz_format_parsers
+
+EXTRA_DIST = coverage.sh make_seed.py


### PR DESCRIPTION
This uses the `COMPILER_CLANG` conditional to add the `fuzz/` subdir. Otherwise, the directory is not included in the tarball created by `make dist`. If one then tries to build from the tarball with `CC=clang`, then `./configure` fails with
```
   config.status: error: cannot find input file: `fuzz/Makefile.in'
```