### PR TITLE
pamu2fcfg: introduce print_authfile_line()

### DIFF
--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -343,6 +343,8 @@ int main(int argc, char *argv[]) {
   exit_code = EXIT_SUCCESS;
 
 err:
+  if (dev != NULL)
+    fido_dev_close(dev);
   fido_dev_info_free(&devlist, ndevs);
   fido_cred_free(&cred);
   fido_dev_free(&dev);

--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018 Yubico AB - See COPYING
+ * Copyright (C) 2014-2021 Yubico AB - See COPYING
  */
 
 #define BUFSIZE 1024

--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -352,5 +352,7 @@ err:
   free(b64_kh);
   free(b64_pk);
 
+  cmdline_parser_free(&args_info);
+
   exit(exit_code);
 }


### PR DESCRIPTION
First step in an attempt of reducing scopes in pamu2fcfg. While here, refactor the main function to always explicitly cleanup allocated memory and close any potentially open device.