### PR TITLE
pamu2fcfg: introduce {prepare,make,verify}_cred()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,12 +76,12 @@ PKG_CHECK_MODULES([LIBCRYPTO], [libcrypto], [], [])
 PKG_CHECK_MODULES([LIBFIDO2], [libfido2 >= 1.3.0], [], [])
 
 
-# Check for secure_getenv, readpassphrase, explicit_bzero, and memset_s
+# Check for secure_getenv, strlcpy, readpassphrase, explicit_bzero, and memset_s
 am_save_CFLAGS="$CFLAGS"
 am_save_LIBS="$LIBS"
 CFLAGS="$CFLAGS"
 LIBS="$LIBS"
-AC_CHECK_FUNCS([secure_getenv readpassphrase explicit_bzero memset_s])
+AC_CHECK_FUNCS([secure_getenv strlcpy readpassphrase explicit_bzero memset_s])
 CFLAGS=$am_save_CFLAGS
 LIBS=$am_save_LIBS
 

--- a/pamu2fcfg/Makefile.am
+++ b/pamu2fcfg/Makefile.am
@@ -8,6 +8,7 @@ bin_PROGRAMS = pamu2fcfg
 pamu2fcfg_SOURCES = pamu2fcfg.c
 pamu2fcfg_SOURCES += cmdline.ggo cmdline.c cmdline.h
 pamu2fcfg_SOURCES += readpassphrase.c _readpassphrase.h
+pamu2fcfg_SOURCES += strlcpy.c openbsd-compat.h
 pamu2fcfg_SOURCES += ../util.c ../b64.c ../explicit_bzero.c
 pamu2fcfg_LDADD = $(LIBFIDO2_LIBS) $(LIBCRYPTO_LIBS)
 

--- a/pamu2fcfg/openbsd-compat.h
+++ b/pamu2fcfg/openbsd-compat.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2021 Yubico AB - See COPYING
+ */
+
+#ifndef _OPENBSD_COMPAT_H
+#define _OPENBSD_COMPAT_H
+
+#include <string.h>
+
+#ifndef HAVE_STRLCPY
+size_t strlcpy(char *, const char *, size_t);
+#endif /* HAVE_STRLCPY */
+
+#ifndef HAVE_READPASSPHRASE
+#include "_readpassphrase.h"
+#else
+#include <readpassphrase.h>
+#endif /* HAVE_READPASSPHRASE */
+
+#endif /* !_STRLCPY_H_ */

--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -20,11 +20,8 @@
 #include "b64.h"
 #include "cmdline.h"
 #include "util.h"
-#ifndef HAVE_READPASSPHRASE
-#include "_readpassphrase.h"
-#else
-#include <readpassphrase.h>
-#endif
+
+#include "openbsd-compat.h"
 
 static fido_cred_t *prepare_cred(const struct gengetopt_args_info *const args) {
   fido_cred_t *cred = NULL;

--- a/pamu2fcfg/strlcpy.c
+++ b/pamu2fcfg/strlcpy.c
@@ -18,6 +18,8 @@
 
 /* OPENBSD ORIGINAL: lib/libc/string/strlcpy.c */
 
+/* clang-format off */
+
 #include "openbsd-compat.h"
 
 #ifndef HAVE_STRLCPY
@@ -57,3 +59,4 @@ strlcpy(char *dst, const char *src, size_t siz)
 }
 
 #endif /* !HAVE_STRLCPY */
+/* clang-format  on */

--- a/pamu2fcfg/strlcpy.c
+++ b/pamu2fcfg/strlcpy.c
@@ -1,0 +1,59 @@
+/*	$OpenBSD: strlcpy.c,v 1.11 2006/05/05 15:27:38 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* OPENBSD ORIGINAL: lib/libc/string/strlcpy.c */
+
+#include "openbsd-compat.h"
+
+#ifndef HAVE_STRLCPY
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Copy src to string dst of size siz.  At most siz-1 characters
+ * will be copied.  Always NUL terminates (unless siz == 0).
+ * Returns strlen(src); if retval >= siz, truncation occurred.
+ */
+size_t
+strlcpy(char *dst, const char *src, size_t siz)
+{
+	char *d = dst;
+	const char *s = src;
+	size_t n = siz;
+
+	/* Copy as many bytes as will fit */
+	if (n != 0) {
+		while (--n != 0) {
+			if ((*d++ = *s++) == '\0')
+				break;
+		}
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src */
+	if (n == 0) {
+		if (siz != 0)
+			*d = '\0';		/* NUL-terminate dst */
+		while (*s++)
+			;
+	}
+
+	return(s - src - 1);	/* count does not include NUL */
+}
+
+#endif /* !HAVE_STRLCPY */


### PR DESCRIPTION
Split parts of `main()` into `{prepare,make,verify}_cred()`.