### PR TITLE
util: plug memory leak

### DIFF
--- a/util.h
+++ b/util.h
@@ -34,7 +34,6 @@
 
 typedef struct {
   unsigned max_devs;
-  const char *client_key;
   int manual;
   int debug;
   int nouserok;


### PR DESCRIPTION
While here, also drop an unused attribute in the `cfg_t` struct.