### PR TITLE
pamu2fcfg, util: add support for EDDSA

### DIFF
--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -218,6 +218,8 @@ static const char *cose_string(int type) {
       return "es256";
     case COSE_RS256:
       return "rs256";
+    case COSE_EDDSA:
+      return "eddsa";
     default:
       return "unknown";
   }

--- a/util.c
+++ b/util.c
@@ -1281,7 +1281,7 @@ static void reset_pk(struct pk *pk) {
 }
 
 
-static int cose_type(const char *str, int *type) {
+int cose_type(const char *str, int *type) {
   if (strcmp(str, "es256") == 0) {
     *type = COSE_ES256;
   } else if (strcmp(str, "rs256") == 0) {

--- a/util.h
+++ b/util.h
@@ -75,6 +75,7 @@ int do_manual_authentication(const cfg_t *cfg, const device_t *devices,
 char *converse(pam_handle_t *pamh, int echocode, const char *prompt);
 void _debug(FILE *, const char *, int, const char *, const char *, ...);
 int random_bytes(void *, size_t);
+int cose_type(const char *, int *);
 
 #if !defined(HAVE_EXPLICIT_BZERO)
 void explicit_bzero(void *, size_t);


### PR DESCRIPTION
While here, also introduce set of helper functions for managing the public keys in the service module.

Note, EDDSA support only implemented for the native format and not the SSH format.