### PR TITLE
util: add support for ed25519-sk

### DIFF
--- a/README
+++ b/README
@@ -326,11 +326,12 @@ It is then possible to generate a credential file with:
 $ ssh-keygen -t ecdsa-sk -f ./credential.ssh
 ----
 
-Note that passphrase protected credentials are currently not supported.
+Supported key types are ecdsa-sk and ed25519-sk. Note that passphrase protected
+credentials are currently not supported.
 
-To use this credential the `authfile` parameter should be set to the
-path of the file `credential.ssh` (or use the default `id_ecdsa_sk`
-name and location) and the `sshformat` option should be set.
+To use this credential the `authfile` parameter should be set to the path of
+the file `credential.ssh` and the `sshformat` option should also be set. If the
+`authfile` parameter is not set, it defaults to `~/.ssh/id_ecdsa_sk`.
 
 [[devices]]
 Multiple Devices

--- a/man/pamu2fcfg.1.txt
+++ b/man/pamu2fcfg.1.txt
@@ -31,7 +31,7 @@ Application ID to use during registration. Defaults to *origin*
 Generate a resident credential. Defaults to off.
 
 *-t*, *--type*=_STRING_::
-COSE type to use during registration (ES256 or RS256). Defaults to ES256.
+COSE type to use during registration (ES256, EDDSA, or RS256). Defaults to ES256.
 
 *-P*, *--no-user-presence*::
 Allow using the credential without ensuring the user's presence.

--- a/pamu2fcfg/cmdline.ggo
+++ b/pamu2fcfg/cmdline.ggo
@@ -7,7 +7,7 @@ defgroup "user"
 
 option "origin" o "Origin URL to use during registration. Defaults to pam://hostname" string optional
 option "appid" i "Application ID to use during registration. Defaults to pam://hostname" string optional
-option "type" t "COSE type to use during registration (ES256 or RS256). Defaults to ES256." string optional
+option "type" t "COSE type to use during registration (ES256, EDDSA, or RS256). Defaults to ES256." string optional
 option "resident" r "Generate a resident credential" flag off
 option "no-user-presence" P "Allow the credential to be used without ensuring the user's presence" flag off
 option "pin-verification" N "Require PIN verification during authentication" flag off

--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -212,19 +212,6 @@ static int verify_cred(const fido_cred_t *const cred) {
   return 0;
 }
 
-static const char *cose_string(int type) {
-  switch (type) {
-    case COSE_ES256:
-      return "es256";
-    case COSE_RS256:
-      return "rs256";
-    case COSE_EDDSA:
-      return "eddsa";
-    default:
-      return "unknown";
-  }
-}
-
 static int print_authfile_line(const struct gengetopt_args_info *const args,
                                const fido_cred_t *const cred) {
   const unsigned char *kh = NULL;

--- a/util.c
+++ b/util.c
@@ -1130,6 +1130,19 @@ int cose_type(const char *str, int *type) {
   return 1;
 }
 
+const char *cose_string(int type) {
+  switch (type) {
+    case COSE_ES256:
+      return "es256";
+    case COSE_RS256:
+      return "rs256";
+    case COSE_EDDSA:
+      return "eddsa";
+    default:
+      return "unknown";
+  }
+}
+
 static int parse_pk(const cfg_t *cfg, int old, const char *type, const char *pk,
                     struct pk *out) {
   unsigned char *buf = NULL;

--- a/util.c
+++ b/util.c
@@ -1139,11 +1139,11 @@ static void reset_pk(struct pk *pk) {
 }
 
 int cose_type(const char *str, int *type) {
-  if (strcmp(str, "es256") == 0) {
+  if (strcasecmp(str, "es256") == 0) {
     *type = COSE_ES256;
-  } else if (strcmp(str, "rs256") == 0) {
+  } else if (strcasecmp(str, "rs256") == 0) {
     *type = COSE_RS256;
-  } else if (strcmp(str, "eddsa") == 0) {
+  } else if (strcasecmp(str, "eddsa") == 0) {
     *type = COSE_EDDSA;
   } else {
     *type = 0;

--- a/util.h
+++ b/util.h
@@ -75,6 +75,7 @@ int do_manual_authentication(const cfg_t *cfg, const device_t *devices,
 char *converse(pam_handle_t *pamh, int echocode, const char *prompt);
 int random_bytes(void *, size_t);
 int cose_type(const char *, int *);
+const char *cose_string(int);
 
 #ifdef __GNUC__
 void _debug(FILE *, const char *, int, const char *, const char *, ...)


### PR DESCRIPTION
Apart from the title, this also

- ~introduces a couple of helpers to with the SSH key parsing,~ (introduced separately in #201)
- fixes a regression in pamu2fcfg argument parsing that slipped by in #199,
- and updates documentation to include native/ssh EDDSA support