### PR TITLE
README: Add missing dependency for Ubuntu build

### DIFF
--- a/README
+++ b/README
@@ -24,7 +24,7 @@ installed using
 [source]
 ----
 # apt install --no-install-recommends autoconf automake libtool pkg-config \
-    libfido2-dev libpam-dev libssl-dev
+    libfido2-dev libcbor-dev libpam-dev libssl-dev
 ----
 
 If you downloaded a tarball, build it as follows.
@@ -59,7 +59,7 @@ necessary dependencies can be installed using
 [source]
 ----
 # apt install --no-install-recommends autoconf automake libtool gengetopt \
-    pkg-config libfido2-dev libpam-dev libssl-dev asciidoc xsltproc \
+    pkg-config libfido2-dev libcbor-dev libpam-dev libssl-dev asciidoc xsltproc \
     libxml2-utils docbook-xml
 ----
 


### PR DESCRIPTION
Fixing this error emitted by the configure script

```
configure: error: Package requirements (libfido2 >= 1.3.0) were not met:

Package 'libcbor', required by 'libfido2', not found
```
