### PR TITLE
ci: update fuzz corpus url and paths

### DIFF
--- a/build-aux/ci/fuzz-linux-asan.sh
+++ b/build-aux/ci/fuzz-linux-asan.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-CORPUS_URL="https://storage.googleapis.com/kroppkaka/corpus/pam-u2f.corpus.tgz"
+CORPUS_URL="https://storage.googleapis.com/yubico-pam-u2f/corpus.tgz"
 
 LIBCBOR_URL="git://github.com/pjk/libcbor"
 LIBCBOR_TAG="v0.8.0"
@@ -64,9 +64,9 @@ make -j $(nproc)
 # fuzz
 curl --retry 4 -s -o corpus.tgz "${CORPUS_URL}"
 tar xzf corpus.tgz
-fuzz/fuzz_format_parsers corpus \
+fuzz/fuzz_format_parsers corpus/format_parsers \
 	-reload=30 -print_pcs=1 -print_funcs=30 -timeout=10 -runs=1
-fuzz/fuzz_auth corpus \
+fuzz/fuzz_auth corpus/auth \
 	-reload=30 -print_pcs=1 -print_funcs=30 -timeout=10 -runs=1
 
 popd &>/dev/null # fakeroot


### PR DESCRIPTION
Split corpus into subfolders while we keep `fuzz_format_parsers` around.

https://github.com/Yubico/pam-u2f/pull/208/checks?check_run_id=3075770515#step:4:1012
```
+ fuzz/fuzz_format_parsers corpus/format_parsers -reload=30 -print_pcs=1 -print_funcs=30 -timeout=10 -runs=1
INFO: Seed: 557801670
INFO: Loaded 2 modules   (3872 inline 8-bit counters): 2507 [0x7f59bf768c70, 0x7f59bf76963b), 1365 [0x5de950, 0x5deea5), 
INFO: Loaded 2 PC tables (3872 PCs): 2507 [0x7f59bf769640,0x7f59bf7732f0), 1365 [0x596590,0x59bae0), 
INFO:      293 files found in corpus/format_parsers
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 293 min: 1b max: 2561b total: 55110b rss: 30Mb
#295	INITED cov: 216 ft: 665 corp: 249/44Kb exec/s: 0 rss: 43Mb
#295	DONE   cov: 216 ft: 665 corp: 249/44Kb lim: 2561 exec/s: 0 rss: 43Mb
Done 295 runs in 0 second(s)
+ fuzz/fuzz_auth corpus/auth -reload=30 -print_pcs=1 -print_funcs=30 -timeout=10 -runs=1
INFO: Seed: 557887105
INFO: Loaded 2 modules   (2784 inline 8-bit counters): 2507 [0x7ff22a31bc70, 0x7ff22a31c63b), 277 [0x5b0f10, 0x5b1025), 
INFO: Loaded 2 PC tables (2784 PCs): 2507 [0x7ff22a31c640,0x7ff22a3262f0), 277 [0x571fe8,0x573138), 
INFO:     3907 files found in corpus/auth
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 3907 min: 26b max: 3563b total: 1326193b rss: 32Mb
#3911	INITED cov: 820 ft: 2337 corp: 653/378Kb exec/s: 0 rss: 250Mb
#3911	DONE   cov: 820 ft: 2337 corp: 653/378Kb lim: 3220 exec/s: 0 rss: 250Mb
Done 3911 runs in 0 second(s)
```