### PR TITLE
ci: replace nproc call on macos builds

### DIFF
--- a/build-aux/ci/build-osx.sh
+++ b/build-aux/ci/build-osx.sh
@@ -10,7 +10,7 @@ pushd "/tmp" &>/dev/null
     git checkout v0.5.0
     cmake -Bbuild -H.
     cmake --build build -- --jobs=2 VERBOSE=1
-    sudo make -j $(nproc) -C build install
+    sudo make -j $(sysctl -n hw.logicalcpu) -C build install
   popd &>/dev/null
 
   # Build and install libfido2
@@ -19,12 +19,12 @@ pushd "/tmp" &>/dev/null
   pushd "/tmp/libfido2" &>/dev/null
     cmake -Bbuild -H.
     cmake --build build -- --jobs=2 VERBOSE=1
-    sudo make -j $(nproc) -C build install
+    sudo make -j $(sysctl -n hw.logicalcpu) -C build install
   popd &>/dev/null
 popd &>/dev/null
 
 pushd "$BUILDROOT" &>/dev/null
   ./autogen.sh
   ./configure --disable-silent-rules --disable-man
-  make -j $(nproc)
+  make -j $(sysctl -n hw.logicalcpu)
 popd &>/dev/null


### PR DESCRIPTION
`nproc` mistakenly found its way into the build scripts for macos. Replace with an analogous `sysctl` call.