### PR TITLE
man: improve documentation on origin/appid

### DIFF
--- a/README
+++ b/README
@@ -121,14 +121,17 @@ considerations). This filename may be alternatively set to "stderr"
 (default), "stdout", or "syslog".
 
 origin=origin::
-Set the origin for the FIDO authentication procedure.
-If no value is specified, the origin "pam://$HOSTNAME" is used.
+Set the relying party ID for the FIDO authentication procedure. If no
+value is specified, the identifier "pam://$HOSTNAME" is used.
 
 appid=appid::
 Set the https://developers.yubico.com/U2F/App_ID.html[application ID]
 for the FIDO authentication procedure. If no value is specified, the
 same value used for origin is taken ("pam://$HOSTNAME" if also origin
-is not specified).
+is not specified). This setting is only applicable for U2F credentials
+created with pamu2fcfg versions v1.0.8 or earlier. Note that on v1.1.0
+and v1.1.1 of pam-u2f, handling of this setting was temporarily broken
+if the value was not the same as the value of origin.
 
 authfile=file::
 Set the location of the <<authMappingFiles,file that holds the mappings of user

--- a/man/pam_u2f.8.txt
+++ b/man/pam_u2f.8.txt
@@ -27,13 +27,17 @@ considerations). This filename may be alternatively set to "stderr"
 (default), "stdout", or "syslog".
 
 *origin*=_origin_::
-Set the origin for the FIDO authentication procedure.
-If no value is specified, the origin "pam://$HOSTNAME" is used.
+Set the relying party ID for the FIDO authentication procedure. If no
+value is specified, the identifier "pam://$HOSTNAME" is used.
 
 *appid*=_appid_::
 Set the application ID for the U2F authentication
 procedure. If no value is specified, the same value used for origin is
-taken ("pam://$HOSTNAME" if also origin is not specified).
+taken ("pam://$HOSTNAME" if also origin is not specified). This setting
+is only applicable for U2F credentials created with pamu2fcfg versions
+v1.0.8 or earlier. Note that on v1.1.0 and v1.1.1 of pam-u2f, handling
+of this setting was temporarily broken if the value was not the same as
+the value of origin.
 
 *authfile*=_file_::
 Set the location of the file that holds the mappings of user

--- a/man/pamu2fcfg.1.txt
+++ b/man/pamu2fcfg.1.txt
@@ -11,7 +11,7 @@ pamu2fcfg - Configuration tool for the U2F PAM module.
 *pamu2fcfg* [_OPTION_]...
 
 == DESCRIPTION
-Perform a U2F registration procedure using a connected U2F token and
+Perform a FIDO2/U2F registration procedure using a connected authenticator and
 output a configuration line that can be used with the U2F PAM module.
 
 == OPTIONS
@@ -22,10 +22,12 @@ Print debug information (highly verbose)
 Print help and exit
 
 *-o*, *--origin*=_STRING_::
-Origin URL to use during registration. Defaults to pam://hostname
+Set the FIDO2 relying party ID to use during registration. Defaults to
+pam://hostname. Before pamu2fcfg v1.1.0, this set the U2F origin URL.
 
 *-i*, *--appid*=_STRING_::
-Application ID to use during registration. Defaults to *origin*
+Set the FIDO2 relying party name to use during registration. Defaults
+to *origin*. Before pamu2fcfg v1.1.0, this set the U2F application ID.
 
 *-r*, *--resident*::
 Generate a resident credential. Defaults to off.

--- a/pamu2fcfg/cmdline.ggo
+++ b/pamu2fcfg/cmdline.ggo
@@ -1,12 +1,12 @@
 #  Copyright (C) 2014-2018 Yubico AB - See COPYING
 #
 
-purpose "Perform a U2F registration operation and print a configuration line that can be used with the pam_u2f module."
+purpose "Perform a FIDO2/U2F registration operation and print a configuration line that can be used with the pam_u2f module."
 
 defgroup "user"
 
-option "origin" o "Origin URL to use during registration. Defaults to pam://hostname" string optional
-option "appid" i "Application ID to use during registration. Defaults to pam://hostname" string optional
+option "origin" o "Relying party ID to use during registration. Defaults to pam://hostname" string optional
+option "appid" i "Relying party name to use during registration. Defaults to the value of origin" string optional
 option "type" t "COSE type to use during registration (ES256, EDDSA, or RS256). Defaults to ES256." string optional
 option "resident" r "Generate a resident credential" flag off
 option "no-user-presence" P "Allow the credential to be used without ensuring the user's presence" flag off


### PR DESCRIPTION
Since pam-u2f/pamu2fcfg 1.1.0, these are the RP ID and RP name
respectively. This (together with #206) resolves #205.