### PR TITLE
ci: revert workaround for libfido2 1.7.0 pkg-config

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,8 +25,7 @@ jobs:
         sudo apt install -y libpam-dev asciidoc autoconf automake libtool \
           software-properties-common libssl-dev pkg-config gengetopt
         sudo apt-add-repository -u -y ppa:yubico/stable
-        # FIXME: workaround for libfido2 1.7.0 pkg-config file (libcbor-dev, libz-dev)
-        sudo apt install -y libfido2-dev libcbor-dev libz-dev
+        sudo apt install -y libfido2-dev
         ./autogen.sh
         ./configure --disable-man
         make

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -23,9 +23,6 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-18.04' }}
       run: |
         sudo add-apt-repository -y ppa:yubico/stable
-        # FIXME: workaround for libfido2 1.7.0 pkg-config file
-        sudo apt -qq update
-        sudo apt -q install -y libcbor-dev libz-dev
     - name: Dependencies
       env:
         CC: ${{ matrix.cc }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,8 +9,7 @@ on:
 env:
   SCAN_IMG:
     yubico-yes-docker-local.jfrog.io/static-code-analysis/c:v1
-  # FIXME: workaround for libfido2 1.7.0 pkg-config file (libcbor-dev, libz-dev)
-  COMPILE_DEPS: "libfido2-dev xsltproc libcbor-dev libz-dev"
+  COMPILE_DEPS: "libfido2-dev xsltproc"
   SECRET: ${{ secrets.ARTIFACTORY_READER_TOKEN }}
 
 jobs:


### PR DESCRIPTION
libfido2 has been updated to 1.8.0 and fixed its pkg-config file.

This reverts commit f704ec7ff92a84f7adfcf6564e4ff6ec26f3b19e.