### PR TITLE
get_devices: include sys/types.h for musl

### DIFF
--- a/tests/get_devices.c
+++ b/tests/get_devices.c
@@ -6,6 +6,10 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#ifndef	__dev_t_defined
+#include <sys/types.h>
+#endif /* __dev_t_defined */
+
 /* These #defines must be present according to PAM documentation. */
 #define PAM_SM_AUTH
 


### PR DESCRIPTION
Without this: I get this error when executing `make check` on musl libc:

```
get_devices.c: In function 'main':
get_devices.c:62:25: error: 'dev_t' undeclared (first use in this function); did you mean 'div_t'?
   62 |   memset(dev, 0, sizeof(dev_t));
      |                         ^~~~~
      |                         div_t
```

With this header included, the 2 tests pass.