### PR TITLE
debug: introduce debug.{c,h}

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-#  Copyright (C) 2014-2018 Yubico AB - See COPYING
+#  Copyright (C) 2014-2021 Yubico AB - See COPYING
 
 SUBDIRS = . pamu2fcfg tests
 
@@ -18,10 +18,11 @@ pampluginexecdir = $(PAMDIR)
 pampluginexec_LTLIBRARIES = pam_u2f.la
 
 pam_u2f_la_SOURCES = pam-u2f.c
-pam_u2f_la_SOURCES += util.c util.h
-pam_u2f_la_SOURCES += drop_privs.h
 pam_u2f_la_SOURCES += b64.c b64.h
+pam_u2f_la_SOURCES += debug.c debug.h
+pam_u2f_la_SOURCES += drop_privs.h
 pam_u2f_la_SOURCES += explicit_bzero.c
+pam_u2f_la_SOURCES += util.c util.h
 
 pam_u2f_la_LIBADD = -lpam
 pam_u2f_la_LIBADD += $(LIBFIDO2_LIBS) $(LIBCRYPTO_LIBS)

--- a/debug.c
+++ b/debug.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2021 Yubico AB - See COPYING
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+
+#include "debug.h"
+
+#define DEBUG_STR "debug(pam_u2f): %s:%d (%s): "
+
+FILE *debug_open(const char *filename) {
+  struct stat st;
+  FILE *file;
+  int fd;
+
+  if (strcmp(filename, "stdout") == 0)
+    return stdout;
+  if (strcmp(filename, "stderr") == 0)
+    return stderr;
+  if (strcmp(filename, "syslog") == 0)
+    return NULL;
+
+  fd = open(filename, O_WRONLY | O_APPEND | O_CLOEXEC | O_NOFOLLOW | O_NOCTTY);
+  if (fd == -1 || fstat(fd, &st) != 0)
+    goto err;
+
+#ifndef WITH_FUZZING
+  if (!S_ISREG(st.st_mode))
+    goto err;
+#endif
+
+  if ((file = fdopen(fd, "a")) != NULL)
+    return file;
+
+err:
+  if (fd != -1)
+    close(fd);
+
+  return DEFAULT_DEBUG_FILE; /* fallback to default */
+}
+
+void debug_close(FILE *f) {
+  if (f != NULL && f != stdout && f != stderr)
+    fclose(f);
+}
+
+void debug_fprintf(FILE *debug_file, const char *file, int line,
+                   const char *func, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+
+#if defined(WITH_FUZZING)
+  (void) debug_file;
+  snprintf(NULL, 0, DEBUG_STR, file, line, func);
+  vsnprintf(NULL, 0, fmt, ap);
+#else
+  if (debug_file == NULL) {
+    syslog(LOG_AUTHPRIV | LOG_DEBUG, DEBUG_STR, file, line, func);
+    vsyslog(LOG_AUTHPRIV | LOG_DEBUG, fmt, ap);
+  } else {
+    fprintf(debug_file, DEBUG_STR, file, line, func);
+    vfprintf(debug_file, fmt, ap);
+    fprintf(debug_file, "\n");
+  }
+#endif
+  va_end(ap);
+}

--- a/debug.h
+++ b/debug.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 Yubico AB - See COPYING
+ */
+
+#ifndef DEBUG_H
+#define DEBUG_H
+
+#include <stdio.h>
+
+#define DEFAULT_DEBUG_FILE stderr
+
+#if defined(DEBUG_PAM)
+#define D(file, ...)                                                           \
+  debug_fprintf(file, __FILE__, __LINE__, __func__, __VA_ARGS__)
+#else
+#define D(file, ...) ((void) 0)
+#endif /* DEBUG_PAM */
+
+#define debug_dbg(cfg, ...)                                                    \
+  do {                                                                         \
+    if (cfg->debug) {                                                          \
+      D(cfg->debug_file, __VA_ARGS__);                                         \
+    }                                                                          \
+  } while (0)
+
+#ifdef __GNUC__
+#define ATTRIBUTE_FORMAT(f, s, a) __attribute__((format(f, s, a)))
+#else
+#define ATTRIBUTE_FORMAT(f, s, a)
+#endif
+
+FILE *debug_open(const char *);
+void debug_close(FILE *f);
+void debug_fprintf(FILE *, const char *, int, const char *, const char *, ...)
+  ATTRIBUTE_FORMAT(printf, 5, 6);
+
+#endif /* DEBUG_H */

--- a/util.c
+++ b/util.c
@@ -15,8 +15,6 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <stdarg.h>
-#include <syslog.h>
 #include <pwd.h>
 #include <errno.h>
 #include <unistd.h>
@@ -24,6 +22,7 @@
 #include <arpa/inet.h>
 
 #include "b64.h"
+#include "debug.h"
 #include "util.h"
 
 #define SSH_HEADER "-----BEGIN OPENSSH PRIVATE KEY-----\n"
@@ -1726,30 +1725,6 @@ char *converse(pam_handle_t *pamh, int echocode, const char *prompt) {
 
   return ret;
 }
-
-#if defined(PAM_DEBUG)
-void _debug(FILE *debug_file, const char *file, int line, const char *func,
-            const char *fmt, ...) {
-  va_list ap;
-  va_start(ap, fmt);
-
-#if defined(WITH_FUZZING)
-  (void) debug_file;
-  snprintf(NULL, 0, DEBUG_STR, file, line, func);
-  vsnprintf(NULL, 0, fmt, ap);
-#else
-  if (debug_file == NULL) {
-    syslog(LOG_AUTHPRIV | LOG_DEBUG, DEBUG_STR, file, line, func);
-    vsyslog(LOG_AUTHPRIV | LOG_DEBUG, fmt, ap);
-  } else {
-    fprintf(debug_file, DEBUG_STR, file, line, func);
-    vfprintf(debug_file, fmt, ap);
-    fprintf(debug_file, "\n");
-  }
-#endif
-  va_end(ap);
-}
-#endif /* PAM_DEBUG */
 
 #ifndef RANDOM_DEV
 #define RANDOM_DEV "/dev/urandom"

--- a/util.h
+++ b/util.h
@@ -24,13 +24,6 @@
 #define DEFAULT_CUE "Please touch the device."
 #define DEFAULT_ORIGIN_PREFIX "pam://"
 #define SSH_ORIGIN "ssh:"
-#define DEBUG_STR "debug(pam_u2f): %s:%d (%s): "
-
-#if defined(DEBUG_PAM)
-#define D(file, ...) _debug(file, __FILE__, __LINE__, __func__, __VA_ARGS__)
-#else
-#define D(file, ...) ((void) 0)
-#endif /* DEBUG_PAM */
 
 typedef struct {
   unsigned max_devs;
@@ -75,13 +68,6 @@ char *converse(pam_handle_t *pamh, int echocode, const char *prompt);
 int random_bytes(void *, size_t);
 int cose_type(const char *, int *);
 const char *cose_string(int);
-
-#ifdef __GNUC__
-void _debug(FILE *, const char *, int, const char *, const char *, ...)
-  __attribute__((__format__(printf, 5, 6)));
-#else
-void _debug(FILE *, const char *, int, const char *, const char *, ...);
-#endif /* __GNUC__ */
 
 #if !defined(HAVE_EXPLICIT_BZERO)
 void explicit_bzero(void *, size_t);


### PR DESCRIPTION
Move debug-related functions here and introduce `debug_dbg()` which can be
used to replace if-debug-debug constructs.