### PR TITLE
debug: only write to debug file once per call

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -68,8 +68,12 @@ static void do_log(FILE *debug_file, const char *file, int line,
 ATTRIBUTE_FORMAT(printf, 5, 0)
 static void debug_vfprintf(FILE *debug_file, const char *file, int line,
                            const char *func, const char *fmt, va_list args) {
+  const char *bn;
   char msg[MSGLEN];
   int r;
+
+  if ((bn = strrchr(file, '/')) != NULL)
+    file = bn + 1;
 
   r = vsnprintf(msg, sizeof(msg), fmt, args);
   do_log(debug_file, file, line, func, r < 0 ? __func__ : msg);

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -161,10 +161,9 @@ static char *resolve_authfile_path(const cfg_t *cfg, const struct passwd *user,
       }
 
       if (!cfg->openasuser) {
-        debug_dbg(cfg,
-                  "WARNING: not dropping privileges when reading %s, please "
-                  "consider setting openasuser=1 in the module configuration",
-                  authfile);
+        debug_dbg(cfg, "WARNING: not dropping privileges when reading the "
+                       "authentication file, please consider setting "
+                       "openasuser=1 in the module configuration");
       }
     }
   } else if (cfg->auth_file[0] != '/') {
@@ -332,7 +331,7 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
       retval = PAM_SUCCESS;
       goto done;
     } else if (retval != 1) {
-      debug_dbg(cfg, "Unable to get devices from file %s", cfg->auth_file);
+      debug_dbg(cfg, "Unable to get devices from authentication file");
       retval = PAM_AUTHINFO_UNAVAIL;
       goto done;
     } else {
@@ -366,7 +365,7 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
 
   int authpending_file_descriptor = -1;
   if (cfg->authpending_file) {
-    debug_dbg(cfg, "Using file '%s' for emitting touch request notifications",
+    debug_dbg(cfg, "Touch request notifications will be emitted via '%s'",
               cfg->authpending_file);
 
     // Open (or create) the authpending_file to indicate that we start waiting
@@ -375,10 +374,8 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
       open(cfg->authpending_file,
            O_RDONLY | O_CREAT | O_CLOEXEC | O_NOFOLLOW | O_NOCTTY, 0664);
     if (authpending_file_descriptor < 0) {
-      debug_dbg(cfg,
-                "Unable to emit 'authentication started' notification by "
-                "opening the file '%s', (%s)",
-                cfg->authpending_file, strerror(errno));
+      debug_dbg(cfg, "Unable to emit 'authentication started' notification: %s",
+                strerror(errno));
     }
   }
 
@@ -394,10 +391,8 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
   // Close the authpending_file to indicate that we stop waiting for a touch
   if (authpending_file_descriptor >= 0) {
     if (close(authpending_file_descriptor) < 0) {
-      debug_dbg(cfg,
-                "Unable to emit 'authentication stopped' notification by "
-                "closing the file '%s', (%s)",
-                cfg->authpending_file, strerror(errno));
+      debug_dbg(cfg, "Unable to emit 'authentication stopped' notification: %s",
+                strerror(errno));
     }
   }
 

--- a/util.c
+++ b/util.c
@@ -178,7 +178,7 @@ static int parse_native_format(const cfg_t *cfg, const char *username,
     if (len > 0 && buf[len - 1] == '\n')
       buf[len - 1] = '\0';
 
-    debug_dbg(cfg, "Authorization line: %s", buf);
+    debug_dbg(cfg, "Read %zu bytes", len);
 
     s_user = strtok_r(buf, ":", &saveptr);
     if (s_user && strcmp(username, s_user) == 0) {
@@ -347,8 +347,6 @@ static int load_ssh_key(const cfg_t *cfg, char *buf, size_t buf_size,
       }
     }
   }
-  // TODO(adma): too verbose? Delete?
-  debug_dbg(cfg, "Credential is \"%s\"", buf);
 
   return 1;
 }
@@ -702,24 +700,22 @@ int get_devices_from_authfile(const cfg_t *cfg, const char *username,
 
   fd = open(cfg->auth_file, O_RDONLY | O_CLOEXEC | O_NOCTTY);
   if (fd < 0) {
-    debug_dbg(cfg, "Cannot open file: %s (%s)", cfg->auth_file,
-              strerror(errno));
+    debug_dbg(cfg, "Cannot open authentication file: %s", strerror(errno));
     goto err;
   }
 
   if (fstat(fd, &st) < 0) {
-    debug_dbg(cfg, "Cannot stat file: %s (%s)", cfg->auth_file,
-              strerror(errno));
+    debug_dbg(cfg, "Cannot stat authentication file: %s", strerror(errno));
     goto err;
   }
 
   if (!S_ISREG(st.st_mode)) {
-    debug_dbg(cfg, "%s is not a regular file", cfg->auth_file);
+    debug_dbg(cfg, "Authentication file is not a regular file");
     goto err;
   }
 
   if (st.st_size == 0) {
-    debug_dbg(cfg, "File %s is empty", cfg->auth_file);
+    debug_dbg(cfg, "Authentication file is empty");
     goto err;
   }
   opwfile_size = st.st_size;


### PR DESCRIPTION
This prevents double syslog entries for each call of `debug_fprintf()` by writing into an internal buffer before passing along the result. This may truncate long debug messages, which should be avoided.

While here, reword potentially long debug messages, remove  redundant or overly verbose debug messages, and print only the basename of the source file (applicable if `pam-u2f` is built out-of-tree).