### PR TITLE
man: collect man page generation rules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,10 @@
-#  Copyright (C) 2014-2021 Yubico AB - See COPYING
+#  Copyright (C) 2014-2022 Yubico AB - See COPYING
 
 SUBDIRS = . pamu2fcfg tests
+
+if ENABLE_MAN
+SUBDIRS += man
+endif
 
 if ENABLE_FUZZING
 SUBDIRS += fuzz
@@ -59,19 +63,6 @@ pam_u2f_la_LDFLAGS += -Wl,--wrap=fido_dev_info_manifest
 endif
 
 DEFS = -DDEBUG_PAM -DPAM_DEBUG @DEFS@
-
-if ENABLE_MAN
-dist_man8_MANS = $(top_builddir)/man/pam_u2f.8
-DISTCLEANFILES = $(dist_man8_MANS)
-
-MANSOURCES = $(top_builddir)/man/pam_u2f.8.txt
-EXTRA_DIST = $(MANSOURCES)
-
-SUFFIXES = .8.txt .8
-
-.8.txt.8:
-	$(A2X) --format=manpage -L -a revdate="Version $(VERSION)" $<
-endif
 
 # Release
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-#  Copyright (C) 2014-2019 Yubico AB
+#  Copyright (C) 2014-2022 Yubico AB
 AC_PREREQ([2.65])
 AC_INIT([pam_u2f], [1.2.1], [https://github.com/Yubico/pam-u2f/issues],
   [pam_u2f], [https://developers.yubico.com/pam-u2f/])
@@ -100,6 +100,7 @@ AC_CONFIG_FILES([
   pamu2fcfg/Makefile
   tests/Makefile
   fuzz/Makefile
+  man/Makefile
 ])
 
 creduser=$(whoami)

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,0 +1,11 @@
+#  Copyright (C) 2022 Yubico AB - See COPYING
+
+dist_man1_MANS = pamu2fcfg.1
+dist_man8_MANS = pam_u2f.8
+MAINTAINERCLEANFILES = $(MANS)
+EXTRA_DIST = $(MANS:=.txt)
+
+SUFFIXES = .1.txt .1 .8.txt .8
+
+.1.txt.1 .8.txt.8:
+	$(AM_V_GEN)$(A2X) --format=manpage -L -a revdate="Version $(VERSION)" $<

--- a/pamu2fcfg/Makefile.am
+++ b/pamu2fcfg/Makefile.am
@@ -1,4 +1,4 @@
-#  Copyright (C) 2014-2018 Yubico AB - See COPYING
+#  Copyright (C) 2014-2022 Yubico AB - See COPYING
 
 AM_CFLAGS = $(CWFLAGS) $(CSFLAGS)
 AM_CPPFLAGS=-I$(srcdir)/.. -I$(builddir)/.. $(LIBFIDO2_CFLAGS)
@@ -17,16 +17,3 @@ cmdline.c cmdline.h: cmdline.ggo Makefile.am
 
 BUILT_SOURCES = cmdline.c cmdline.h
 MAINTAINERCLEANFILES = $(BUILT_SOURCES)
-
-if ENABLE_MAN
-dist_man1_MANS = $(top_builddir)/man/pamu2fcfg.1
-DISTCLEANFILES = $(dist_man1_MANS)
-
-MANSOURCES = $(top_builddir)/man/pamu2fcfg.1.txt
-EXTRA_DIST = $(MANSOURCES)
-
-SUFFIXES = .1.txt .1
-
-.1.txt.1:
-	$(A2X) --format=manpage -L -a revdate="Version $(VERSION)" $<
-endif


### PR DESCRIPTION
`DISTCLEANFILES` is replaced with `MAINTAINERCLEANFILES`, the former is
primarily intended for files generated by `configure`. We are
distributing the generated man pages as if they were source files.