### PR TITLE
pamu2fcfg: prevent parallel generation of cmdline.[ch]

### DIFF
--- a/pamu2fcfg/Makefile.am
+++ b/pamu2fcfg/Makefile.am
@@ -1,7 +1,7 @@
 #  Copyright (C) 2014-2022 Yubico AB - See COPYING
 
 AM_CFLAGS = $(CWFLAGS) $(CSFLAGS)
-AM_CPPFLAGS=-I$(srcdir)/.. -I$(builddir)/.. $(LIBFIDO2_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/.. $(LIBFIDO2_CFLAGS)
 
 bin_PROGRAMS = pamu2fcfg
 
@@ -12,8 +12,8 @@ pamu2fcfg_SOURCES += strlcpy.c openbsd-compat.h
 pamu2fcfg_SOURCES += ../util.c ../b64.c ../explicit_bzero.c
 pamu2fcfg_LDADD = $(LIBFIDO2_LIBS) $(LIBCRYPTO_LIBS)
 
-cmdline.c cmdline.h: cmdline.ggo Makefile.am
-	gengetopt --no-handle-help --input $^
+%.c %.h: %.ggo
+	$(AM_V_GEN)gengetopt --no-handle-help --input $<
 
 BUILT_SOURCES = cmdline.c cmdline.h
 MAINTAINERCLEANFILES = $(BUILT_SOURCES)


### PR DESCRIPTION
Running make in parallel would spawn two instances of gengetopt. To
prevent this, use a GNU make pattern rule which is able to express rules
with multiple output files. Other make implementations should still be
able to build from the tarballs. While here, remove an unnecessary
include path.