### PR TITLE
fuzz: export get_devices_from_authfile() 

### DIFF
--- a/fuzz/export.sym
+++ b/fuzz/export.sym
@@ -1,5 +1,6 @@
 pam_sm_authenticate
 pam_sm_setcred
+get_devices_from_authfile
 set_authfile
 set_conv
 set_user

--- a/fuzz/fuzz_auth.c
+++ b/fuzz/fuzz_auth.c
@@ -1,4 +1,7 @@
-/* Copyright (C) 2021 Yubico AB - See COPYING */
+/* Copyright (C) 2021-2022 Yubico AB - See COPYING */
+#include <sys/types.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <assert.h>
 #include <err.h>
 #include <errno.h>
@@ -6,9 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 #include "fuzz/fuzz.h"

--- a/fuzz/fuzz_format_parsers.c
+++ b/fuzz/fuzz_format_parsers.c
@@ -1,12 +1,13 @@
 /*
- * Copyright (C) 2020 Yubico AB - See COPYING
+ * Copyright (C) 2020-2022 Yubico AB - See COPYING
  */
-#include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "fuzz/fuzz.h"


### PR DESCRIPTION
Have `fuzz_format_parsers` use this function instead of the two private
authfile parsers. This is made possible via the mocking utilities
introduced along with `fuzz_auth` and enables us to not have to include
the relevant sources directly in the fuzzer harness source.