### PR TITLE
FAQ: YubiKey 4 does not support asking for pin

### DIFF
--- a/README
+++ b/README
@@ -211,18 +211,18 @@ authentication, the "nodetect" option was added.
 
 userpresence=int::
 If 1, request user presence during authentication. If 0, do not
-request user presence during authentication. Otherwise, fallback to
+request user presence during authentication. If omitted, fallback to
 the authenticator's default behaviour.
 
 userverification=int::
 If 1, request user verification during authentication (e.g. biometrics).
-If 0, do not request user verification during authentication. Otherwise,
+If 0, do not request user verification during authentication. If omitted,
 fallback to the authenticator's default behaviour. If enabled, an
 authenticator with support for FIDO2 user verification is required.
 
 pinverification=int::
 If 1, request PIN verification during authentication. If 0, do not
-request PIN verification during authentication. Otherwise, fallback to
+request PIN verification during authentication. If omitted, fallback to
 the authenticator's default behaviour. If enabled, an authenticator
 with support for a FIDO2 PIN is required.
 

--- a/README
+++ b/README
@@ -381,6 +381,10 @@ should be used.
 For more information see
 https://access.redhat.com/security/cve/CVE-2020-24612[HERE].
 
-FIDO _vs_ FIDO2
----------------
-Devices that solely support FIDO and not FIDO2, _e.g._ YubiKey 4 series, can be used only in conjunction with the `+presence` flag. Setting either the `+pin` or the `+verification` flags in the `authfile` file or the `pinverification=1` option in `pam.d` causes the device to be ignored.
+FIDO U2F vs FIDO2
+-----------------
+Devices that solely support FIDO U2F and not FIDO2, e.g. the YubiKey 4 series,
+can be used only in conjunction with compatible features. Enabling incompatible
+features, such as setting the `+pin` or the `+verification` flags in the
+`authfile` or the corresponding options in the PAM service configuration causes
+the device to be ignored.

--- a/README
+++ b/README
@@ -380,3 +380,7 @@ should be used.
 
 For more information see
 https://access.redhat.com/security/cve/CVE-2020-24612[HERE].
+
+FIDO _vs_ FIDO2
+---------------
+Devices that solely support FIDO and not FIDO2, _e.g._ YubiKey 4 series, can be used only in conjunction with the `+presence` flag. Setting either the `+pin` or the `+verification` flags in the `authfile` file or the `pinverification=1` option in `pam.d` causes the device to be ignored.

--- a/README
+++ b/README
@@ -215,14 +215,16 @@ request user presence during authentication. Otherwise, fallback to
 the authenticator's default behaviour.
 
 userverification=int::
-If 1, request user verification during authentication. If 0, do not
-request user verification during authentication. Otherwise, fallback
-to the authenticator's default behaviour.
+If 1, request user verification during authentication (e.g. biometrics).
+If 0, do not request user verification during authentication. Otherwise,
+fallback to the authenticator's default behaviour. If enabled, an
+authenticator with support for FIDO2 user verification is required.
 
 pinverification=int::
 If 1, request PIN verification during authentication. If 0, do not
 request PIN verification during authentication. Otherwise, fallback to
-the authenticator's default behaviour.
+the authenticator's default behaviour. If enabled, an authenticator
+with support for a FIDO2 PIN is required.
 
 sshformat::
 Use credentials produced by versions of OpenSSH that have support for

--- a/man/pam_u2f.8.txt
+++ b/man/pam_u2f.8.txt
@@ -108,18 +108,18 @@ authentication. See *NOTES* below.
 
 *userpresence*=_int_::
 If 1, require user presence during authentication. If 0, do not
-request user presence during authentication. Otherwise, fallback to
+request user presence during authentication. If omitted, fallback to
 the authenticator's default behaviour.
 
 *userverification*=_int_::
 If 1, require user verification during authentication (e.g. biometrics).
-If 0, do not request user verification during authentication. Otherwise,
+If 0, do not request user verification during authentication. If omitted,
 fallback to the authenticator's default behaviour. If enabled, an
 authenticator with support for FIDO2 user verification is required.
 
 *pinverification*=_int_::
 If 1, require PIN verification during authentication. If 0, do not
-request PIN verification during authentication. Otherwise, fallback to
+request PIN verification during authentication. If omitted, fallback to
 the authenticator's default behaviour. If enabled, an authenticator with
 support for a FIDO2 PIN is required.
 

--- a/man/pam_u2f.8.txt
+++ b/man/pam_u2f.8.txt
@@ -112,14 +112,16 @@ request user presence during authentication. Otherwise, fallback to
 the authenticator's default behaviour.
 
 *userverification*=_int_::
-If 1, require user verification during authentication. If 0, do not
-request user verification during authentication. Otherwise, fallback
-to the authenticator's default behaviour.
+If 1, require user verification during authentication (e.g. biometrics).
+If 0, do not request user verification during authentication. Otherwise,
+fallback to the authenticator's default behaviour. If enabled, an
+authenticator with support for FIDO2 user verification is required.
 
 *pinverification*=_int_::
 If 1, require PIN verification during authentication. If 0, do not
 request PIN verification during authentication. Otherwise, fallback to
-the authenticator's default behaviour.
+the authenticator's default behaviour. If enabled, an authenticator with
+support for a FIDO2 PIN is required.
 
 *sshformat*::
 Use credentials produced by versions of OpenSSH that have support for


### PR DESCRIPTION
Explicitly state YubiKey 4 series does not support asking for pin.

__Problem__
* FIDO(1) devices are only partially supported. They can be used as a second authentication factor to the password or as a single factor by themselves, but they cannot be used in conjunction with a `pin`.

* The failure mode consists in silently ignoring the device.
It does not provide any feedback as to why the authentication procedure is failing and it's thus very complicated to debug (see for example #144).

* YubiKey product pages, understandably, do not highlight the differences between FIDO and FIDO2, users may thus not realize at a first glance what their devices do actually support.

__This PR__
Add a paragraph to help users like myself understand why their YubiKeys work only half of the time.

__Next steps__
Modify `pamu2fcfg` to emit a warning when registering devices with unsupported configurations.