### PR TITLE
man: sync manpages with pamu2fcfg help text

### DIFF
--- a/man/pamu2fcfg.1.txt
+++ b/man/pamu2fcfg.1.txt
@@ -48,13 +48,12 @@ Require user verification during authentication. Defaults to off.
 *--version*:
 *Print version and exit*
 
-Group: user (mutually exclusive)
-
 *-u*, *--username*=_STRING_::
-The name of the user registering the device. Defaults to the current user name
+The name of the user registering the device. Defaults to the current user name.
 
 *-n*, *--nouser*::
-Print only registration information (keyHandle and public key). Useful for appending
+Print only registration information (key handle, public key, and options).
+Useful for appending.
 
 == BUGS
 Report pamu2fcfg bugs in the issue tracker: https://github.com/Yubico/pam-u2f/issues


### PR DESCRIPTION
`--username` and `--nouser` are no longer mutually exclusive as they serve different purposes.