### PR TITLE
tests: prefer getpwuid over getenv

### DIFF
--- a/.github/workflows/alpine_builds.yml
+++ b/.github/workflows/alpine_builds.yml
@@ -23,6 +23,5 @@ jobs:
     - name: build
       env:
         CC: ${{ matrix.cc }}
-        USER: root
       run: |
         ./build-aux/ci/build-linux-${CC%-*}.sh

--- a/tests/get_devices.c
+++ b/tests/get_devices.c
@@ -3,9 +3,12 @@
  */
 
 #undef NDEBUG
+#include <sys/types.h>
+#include <assert.h>
+#include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
+#include <unistd.h>
 
 #include <string.h>
 #include "../util.h"
@@ -718,15 +721,16 @@ static void test_new_credentials(const char *username) {
 }
 
 int main(void) {
-  const char *username;
+  struct passwd *pwd;
+  char *username;
 
-  if ((username = getenv("USER")) == NULL) {
-    username = getenv("LOGNAME");
-  }
-  assert(username != NULL);
+  assert((pwd = getpwuid(geteuid())) != NULL);
+  assert((username = strdup(pwd->pw_name)) != NULL);
 
   test_ssh_credential(username);
   test_old_credential(username);
   test_limited_count(username);
   test_new_credentials(username);
+
+  free(username);
 }


### PR DESCRIPTION
`$USER` may not be set, look up the username of the effective user ID
from the password database instead. In the long term, consider splitting
authfile handling and parsing to simplify testing.