### PR TITLE
pamu2fcfg: sanity check UV options

### DIFF
--- a/README
+++ b/README
@@ -365,6 +365,12 @@ configuration line that can be directly used with the module. For
 additional information on the tool read the relative manpage (`man
 pamu2fcfg`).
 
+For authenticator management (e.g. setting a PIN, enrolling fingerprints, and
+more), please refer to
+https://developers.yubico.com/libfido2/Manuals/fido2-token.html[`fido2-token`],
+https://developers.yubico.com/yubikey-manager[`yubikey-manager`], or some other
+suitable tool.
+
 === SSH Credentials
 
 To generate SSH credentials OpenSSH version 8.2 or later is required.

--- a/man/pamu2fcfg.1.txt
+++ b/man/pamu2fcfg.1.txt
@@ -59,7 +59,7 @@ Useful for appending.
 Report pamu2fcfg bugs in the issue tracker: https://github.com/Yubico/pam-u2f/issues
 
 == SEE ALSO
-*pam_u2f*(8), *pam*(7)
+*pam_u2f*(8), *pam*(7), *fido2-token*(1)
 
 The pam-u2f home page: https://developers.yubico.com/pam-u2f/
 

--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -399,9 +399,6 @@ int main(int argc, char *argv[]) {
   parse_args(argc, argv, &args);
   fido_init(args.debug ? FIDO_DEBUG : 0);
 
-  if ((cred = prepare_cred(&args)) == NULL)
-    goto err;
-
   devlist = fido_dev_info_new(64);
   if (!devlist) {
     fprintf(stderr, "error: fido_dev_info_new failed\n");
@@ -467,6 +464,9 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "error: fido_dev_open (%d) %s\n", r, fido_strerr(r));
     goto err;
   }
+
+  if ((cred = prepare_cred(&args)) == NULL)
+    goto err;
 
   if (make_cred(path, dev, cred) != 0 || verify_cred(cred) != 0 ||
       print_authfile_line(&args, cred) != 0)

--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -199,7 +199,8 @@ static int make_cred(const struct args *args, const char *path, fido_dev_t *dev,
 
   /* Some form of UV required; built-in UV failed or is not available. */
   if ((devopts & PIN_SET) &&
-      (r == FIDO_ERR_PIN_REQUIRED || r == FIDO_ERR_UV_BLOCKED)) {
+      (r == FIDO_ERR_PIN_REQUIRED || r == FIDO_ERR_UV_BLOCKED ||
+       r == FIDO_ERR_PIN_BLOCKED)) {
     n = snprintf(prompt, sizeof(prompt), "Enter PIN for %s: ", path);
     if (n < 0 || (size_t) n >= sizeof(prompt)) {
       fprintf(stderr, "error: snprintf prompt");


### PR DESCRIPTION
Perform basic sanity checking of the user's selected authentication UV options and exercise chosen UV method(s) on credential creation. This fixes #278.