### PR TITLE
pam: add opt-in for %u expansion in authfile path

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2022 Yubico AB
+Copyright (c) 2014-2023 Yubico AB
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ libmodule_la_SOURCES = pam-u2f.c
 libmodule_la_SOURCES += b64.c b64.h
 libmodule_la_SOURCES += debug.c debug.h
 libmodule_la_SOURCES += drop_privs.h
+libmodule_la_SOURCES += expand.c
 libmodule_la_SOURCES += explicit_bzero.c
 libmodule_la_SOURCES += util.c util.h
 libmodule_la_LIBADD = -lpam $(LIBFIDO2_LIBS) $(LIBCRYPTO_LIBS)

--- a/README
+++ b/README
@@ -140,6 +140,11 @@ file>> may be configured relative to the users' home dirs, e.g.
 $XDG_CONFIG_HOME/Yubico/u2f_keys. If $XDG_CONFIG_HOME is not set,
 $HOME/.config/Yubico/u2f_keys is used.
 
+expand::
+Enables variable expansion within the authfile path: `%u` is expanded to the
+local user name (`PAM_USER`) and `%%` is expanded to `%`. Unknown expansion
+sequences result in an authentication error. See also `openasuser`.
+
 authpending_file=file::
 Set the location of the file that is used for touch request
 notifications. This file will be opened when pam-u2f starts waiting

--- a/README
+++ b/README
@@ -167,8 +167,8 @@ Setuid to the authenticating user when opening the authfile. Useful
 when the user's home is stored on an NFS volume mounted with the
 `root_squash` option (which maps root to nobody which will not be able
 to read the file). Note that after release 1.0.8 this is done by
-default when no global authfile or XDG_CONFIG_HOME environment
-variable has been set.
+default when no global authfile (path is absolute) or XDG_CONFIG_HOME
+environment variable has been set.
 
 alwaysok::
 Set to enable all authentication attempts to succeed (aka presentation

--- a/expand.c
+++ b/expand.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 Yubico AB - See COPYING
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+#include "util.h"
+
+static int buf_write(uint8_t **dst, size_t *size, const void *src, size_t n) {
+  if (*size < n) {
+    return -1;
+  }
+
+  memcpy(*dst, src, n);
+  *dst += n;
+  *size -= n;
+
+  return 0;
+}
+
+static int buf_write_byte(uint8_t **dst, size_t *size, uint8_t c) {
+  return buf_write(dst, size, &c, sizeof(c));
+}
+
+static const char *lookup(char var, const char *user) {
+  switch (var) {
+    case 'u':
+      return user;
+    case '%':
+      return "%";
+    default:
+      // Capture all unknown variables (incl. null byte).
+      return NULL;
+  }
+}
+
+char *expand_variables(const char *str, const char *user) {
+  uint8_t *tail, *head;
+  size_t size = PATH_MAX;
+  int ok = -1;
+
+  if (str == NULL || (tail = head = malloc(size)) == NULL) {
+    return NULL;
+  }
+
+  for (; *str != '\0'; str++) {
+    if (*str == '%') {
+      str++;
+      const char *value = lookup(*str, user);
+      if (value == NULL || *value == '\0' ||
+          buf_write(&head, &size, value, strlen(value)) != 0) {
+        goto fail;
+      }
+    } else if (buf_write_byte(&head, &size, *str) != 0) {
+      goto fail;
+    }
+  }
+
+  ok = buf_write_byte(&head, &size, '\0');
+
+fail:
+  if (ok != 0) {
+    free(tail);
+    return NULL;
+  }
+  return (char *) tail;
+}

--- a/man/pam_u2f.8.txt
+++ b/man/pam_u2f.8.txt
@@ -48,6 +48,11 @@ $XDG_CONFIG_HOME/Yubico/u2f_keys. If $XDG_CONFIG_HOME is not set,
 $HOME/.config/Yubico/u2f_keys is used. The authfile format is
 <username>:<KeyHandle1>,<UserKey1>,<CoseType1>,<Options1>:<KeyHandle2>,<UserKey2>,<CoseType2>,<Options2>:...
 
+*expand*::
+Enables variable expansion within the authfile path: `%u` is expanded to the
+local user name (`PAM_USER`) and `%%` is expanded to `%`. Unknown expansion
+sequences result in an authentication error. See also `openasuser`.
+
 *authpending_file*=_file_::
 Set the location of the file that is used for touch request
 notifications. This file will be opened when pam-u2f starts waiting

--- a/man/pam_u2f.8.txt
+++ b/man/pam_u2f.8.txt
@@ -72,8 +72,8 @@ Setuid to the authenticating user when opening the authfile. Useful
 when the user's home is stored on an NFS volume mounted with the
 root_squash option (which maps root to nobody which will not be able
 to read the file). Note that after release 1.0.8 this is done by
-default when no global authfile or XDG_CONFIG_HOME environment
-variable has been set.
+default when no global authfile (path is absolute) or XDG_CONFIG_HOME
+environment variable has been set.
 
 *alwaysok*::
 Set to enable all authentication attempts to succeed (aka presentation

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,4 +13,7 @@ dlsym_check_LDFLAGS = -ldl $(AM_LDFLAGS)
 check_PROGRAMS += get_devices
 get_devices_LDADD = $(top_builddir)/libmodule.la
 
+check_PROGRAMS += expand
+expand_LDADD = $(top_builddir)/libmodule.la
+
 TESTS = $(check_PROGRAMS)

--- a/tests/expand.c
+++ b/tests/expand.c
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2023 Yubico AB - See COPYING
+ */
+
+#undef NDEBUG
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include "util.h"
+
+#define ASSERT_STR_EQ(a, b) assert(!strcmp(a, b))
+#define ASSERT_EXPANDED_EQ(str, user, result)                                  \
+  do {                                                                         \
+    char *tmp = expand_variables(str, user);                                   \
+    assert(tmp != NULL);                                                       \
+    ASSERT_STR_EQ(tmp, result);                                                \
+    free(tmp);                                                                 \
+  } while (0)
+
+#define ASSERT_NULL(x) assert((x) == NULL)
+
+int main(void) {
+  ASSERT_EXPANDED_EQ("foobar", "user", "foobar");
+  ASSERT_EXPANDED_EQ("", "user", "");
+  ASSERT_EXPANDED_EQ("%%", "user", "%");
+  ASSERT_EXPANDED_EQ("%u", "user", "user");
+  ASSERT_EXPANDED_EQ("x%u", "user", "xuser");
+  ASSERT_EXPANDED_EQ("%ux", "user", "userx");
+  ASSERT_EXPANDED_EQ("x%ux", "user", "xuserx");
+  ASSERT_EXPANDED_EQ("%%%u", "user", "%user");
+  ASSERT_EXPANDED_EQ("%u%%", "user", "user%");
+  ASSERT_EXPANDED_EQ("%%u", "user", "%u");
+  ASSERT_EXPANDED_EQ("%u", "%user", "%user");
+  ASSERT_EXPANDED_EQ("%u%u", "user", "useruser");
+  ASSERT_EXPANDED_EQ("%%%u%%", "user", "%user%");
+
+  ASSERT_NULL(expand_variables("%", "user"));  // Unexpected end of string.
+  ASSERT_NULL(expand_variables("%x", "user")); // Unknown variable.
+  ASSERT_NULL(expand_variables("%u", ""));     // Disallow empty username.
+
+  return 0;
+}

--- a/util.h
+++ b/util.h
@@ -35,6 +35,7 @@ typedef struct {
   int userverification;
   int pinverification;
   int sshformat;
+  int expand;
   const char *auth_file;
   const char *authpending_file;
   const char *origin;

--- a/util.h
+++ b/util.h
@@ -64,6 +64,7 @@ char *converse(pam_handle_t *pamh, int echocode, const char *prompt);
 int random_bytes(void *, size_t);
 int cose_type(const char *, int *);
 const char *cose_string(int);
+char *expand_variables(const char *, const char *);
 
 #if !defined(HAVE_EXPLICIT_BZERO)
 void explicit_bzero(void *, size_t);


### PR DESCRIPTION
Add a toggle for enabling variable expansion in the authfile path. Accepted variables are `%u` (replaced with the value of `PAM_USER`) and `%%` (replaced with a `%`), any other variable will cause the module to return an error. Variable expansion is performed before any default or relative paths are resolved.

Resolves #218.