### PR TITLE
authtok: add support for decrypting an auth token

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,7 @@ libmodule_la_SOURCES += drop_privs.h
 libmodule_la_SOURCES += expand.c
 libmodule_la_SOURCES += explicit_bzero.c
 libmodule_la_SOURCES += util.c util.h
+libmodule_la_SOURCES += authtok.c authtok.h
 libmodule_la_LIBADD = -lpam $(LIBFIDO2_LIBS) $(LIBCRYPTO_LIBS)
 
 pampluginexecdir = $(PAMDIR)

--- a/authtok.c
+++ b/authtok.c
@@ -1,0 +1,261 @@
+#include <fido.h>
+#include <fido/types.h>
+#include <openssl/evp.h>
+#include <stdio.h>
+
+#include "authtok.h"
+#include "b64.h"
+
+static int
+encrypt_authtok(const unsigned char *plaintext, size_t plaintext_len,
+                const unsigned char *key, /* 32 bytes */
+                unsigned char *tag,       /* 16 bytes */
+                unsigned char *ciphertext /* equal to plaintext_len */
+) {
+  EVP_CIPHER_CTX *ctx = NULL;
+  EVP_CIPHER *cipher = NULL;
+  int len;
+  int retval = 0;
+  unsigned char iv[12] = {0};
+
+  if (!(ctx = EVP_CIPHER_CTX_new())) {
+    goto err;
+  }
+  if (!(cipher = EVP_CIPHER_fetch(NULL, "AES-256-GCM", NULL))) {
+    goto err;
+  }
+  if (!EVP_EncryptInit_ex2(ctx, cipher, key, iv, NULL)) {
+    goto err;
+  }
+  if (plaintext_len > INT_MAX) {
+    goto err;
+  }
+  if (!EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext,
+                         (int) plaintext_len)) {
+    goto err;
+  }
+  if (!EVP_EncryptFinal_ex(ctx, ciphertext + len, &len)) {
+    goto err;
+  }
+  if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, 16, (void *) tag)) {
+    goto err;
+  }
+  retval = 1;
+
+err:
+  EVP_CIPHER_CTX_free(ctx);
+  EVP_CIPHER_free(cipher);
+  return retval;
+}
+
+static int
+decrypt_authtok(const unsigned char *ciphertext, size_t ciphertext_len,
+                const unsigned char *key, /* 32 bytes */
+                const unsigned char *tag, /* 16 bytes */
+                unsigned char *plaintext  /* equal to ciphertext_len */
+) {
+  EVP_CIPHER_CTX *ctx = NULL;
+  EVP_CIPHER *cipher = NULL;
+  int len;
+  int retval = 0;
+  unsigned char iv[12] = {0};
+
+  if (!(ctx = EVP_CIPHER_CTX_new())) {
+    goto err;
+  }
+  if (!(cipher = EVP_CIPHER_fetch(NULL, "AES-256-GCM", NULL))) {
+    goto err;
+  }
+  if (!EVP_DecryptInit_ex2(ctx, cipher, key, iv, NULL)) {
+    goto err;
+  }
+  if (ciphertext_len > INT_MAX) {
+    goto err;
+  }
+  if (!EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext,
+                         (int) ciphertext_len)) {
+    goto err;
+  }
+  if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, 16, (void *) tag)) {
+    goto err;
+  }
+  if (!EVP_DecryptFinal_ex(ctx, plaintext + len, &len)) {
+    goto err;
+  }
+  retval = 1;
+
+err:
+  EVP_CIPHER_CTX_free(ctx);
+  EVP_CIPHER_free(cipher);
+  return retval;
+}
+
+int get_authtok(const fido_assert_t *assert, const char *enc_authtok,
+                char **authtok, size_t *authtok_len) {
+  unsigned char *buf = NULL;
+  size_t buf_len;
+  const unsigned char *key;
+  size_t key_len;
+  size_t stmt_count;
+  int ok = 0;
+
+  *authtok = NULL;
+
+  if (!b64_decode(enc_authtok, (void **) &buf, &buf_len) ||
+      buf_len <= HMAC_SALT_SIZE + AEAD_TAG_SIZE) {
+    goto err;
+  }
+
+  if ((stmt_count = fido_assert_count(assert)) != 1) {
+    goto err;
+  }
+
+  if ((key = fido_assert_hmac_secret_ptr(assert, 0)) == NULL) {
+    goto err;
+  }
+  if ((key_len = fido_assert_hmac_secret_len(assert, 0)) != HMAC_SECRET_SIZE) {
+    goto err;
+  }
+
+  *authtok_len = buf_len - HMAC_SALT_SIZE - AEAD_TAG_SIZE;
+  if (!(*authtok = malloc(*authtok_len + 1))) {
+    goto err;
+  }
+  if (!decrypt_authtok(buf + HMAC_SALT_SIZE,
+                       buf_len - HMAC_SALT_SIZE - AEAD_TAG_SIZE, key,
+                       buf + buf_len - AEAD_TAG_SIZE,
+                       (unsigned char *) *authtok)) {
+    goto err;
+  }
+  (*authtok)[*authtok_len] = '\0';
+
+  ok = 1;
+
+err:
+  free(buf);
+  if (!ok) {
+    if (*authtok) {
+      explicit_bzero(*authtok, *authtok_len);
+      free(*authtok);
+      *authtok = NULL;
+      *authtok_len = 0;
+    }
+  }
+  return ok;
+}
+
+static int get_hmac_secret(fido_dev_t *dev, fido_cred_t *cred, fido_opt_t uv,
+                           const char *pin, const unsigned char *salt,
+                           unsigned char *secret) {
+  fido_assert_t *assert = NULL;
+  unsigned char cdh[32] = {0};
+  const unsigned char *kh = NULL;
+  const unsigned char *hmac_secret;
+  size_t kh_len;
+  size_t hmac_secret_len;
+  const char *id;
+  int retval = 0;
+
+  if ((assert = fido_assert_new()) == NULL) {
+    goto err;
+  }
+
+  if (!(id = fido_cred_rp_id(cred))) {
+    goto err;
+  }
+
+  if (fido_assert_set_rp(assert, id) != FIDO_OK) {
+    goto err;
+  }
+
+  if ((kh = fido_cred_id_ptr(cred)) == NULL) {
+    goto err;
+  }
+
+  if ((kh_len = fido_cred_id_len(cred)) == 0) {
+    goto err;
+  }
+
+  if (fido_assert_allow_cred(assert, kh, kh_len) != FIDO_OK) {
+    goto err;
+  }
+
+  if (fido_assert_set_clientdata_hash(assert, cdh, 32) != FIDO_OK) {
+    goto err;
+  }
+
+  if (fido_assert_set_uv(assert, uv) != FIDO_OK) {
+    goto err;
+  }
+
+  if (fido_assert_set_extensions(assert, FIDO_EXT_HMAC_SECRET) != FIDO_OK) {
+    goto err;
+  }
+
+  if (fido_assert_set_hmac_salt(assert, salt, HMAC_SALT_SIZE) != FIDO_OK) {
+    goto err;
+  }
+
+  if (fido_dev_get_assert(dev, assert, pin) != FIDO_OK) {
+    goto err;
+  }
+
+  if (fido_assert_count(assert) != 1) {
+    goto err;
+  }
+
+  if ((hmac_secret = fido_assert_hmac_secret_ptr(assert, 0)) == NULL) {
+    goto err;
+  }
+
+  if ((hmac_secret_len = fido_assert_hmac_secret_len(assert, 0)) !=
+      HMAC_SECRET_SIZE) {
+    goto err;
+  }
+
+  memcpy(secret, hmac_secret, hmac_secret_len);
+  retval = 1;
+
+err:
+  fido_assert_free(&assert);
+  return retval;
+}
+
+int generate_encrypted_authtok(fido_dev_t *dev, fido_cred_t *cred,
+                               const char *authtok, fido_opt_t uv,
+                               const char *pin, unsigned char **enc_authtok,
+                               size_t *enc_authtok_len) {
+  size_t authtok_len;
+  unsigned char key[32];
+  int ok = 0;
+
+  authtok_len = strlen(authtok);
+  *enc_authtok_len = HMAC_SALT_SIZE + authtok_len + AEAD_TAG_SIZE;
+  if ((*enc_authtok = malloc(*enc_authtok_len)) == NULL) {
+    goto err;
+  }
+  if (!random_bytes(*enc_authtok, HMAC_SALT_SIZE)) {
+    goto err;
+  }
+  if (!get_hmac_secret(dev, cred, uv, pin, *enc_authtok, key)) {
+    goto err;
+  }
+  if (!encrypt_authtok((unsigned char *) authtok, authtok_len, key,
+                       *enc_authtok + HMAC_SALT_SIZE + authtok_len,
+                       *enc_authtok + HMAC_SALT_SIZE)) {
+    goto err;
+  }
+  ok = 1;
+
+err:
+  explicit_bzero(key, sizeof(key));
+  if (!ok) {
+    if (*enc_authtok) {
+      explicit_bzero(*enc_authtok, *enc_authtok_len);
+      free(*enc_authtok);
+      *enc_authtok = NULL;
+      *enc_authtok_len = 0;
+    }
+  }
+  return ok;
+}

--- a/authtok.h
+++ b/authtok.h
@@ -1,0 +1,20 @@
+#ifndef AUTHTOK_H
+#define AUTHTOK_H
+
+#include <fido.h>
+
+#include "util.h"
+
+#define HMAC_SALT_SIZE 32
+#define HMAC_SECRET_SIZE 32
+#define AEAD_TAG_SIZE 16
+
+int get_authtok(const fido_assert_t *assert, const char *enc_authtok,
+                char **authtok, size_t *authtok_len);
+
+int generate_encrypted_authtok(fido_dev_t *dev, fido_cred_t *cred,
+                               const char *authtok, fido_opt_t uv,
+                               const char *pin, unsigned char **enc_authtok,
+                               size_t *enc_authtok_len);
+
+#endif /* UTIL_H */

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -65,6 +65,8 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t *cfg) {
       cfg->nodetect = 1;
     } else if (strcmp(argv[i], "expand") == 0) {
       cfg->expand = 1;
+    } else if (strcmp(argv[i], "allowauthtok") == 0) {
+      cfg->allowauthtok = 1;
     } else if (strncmp(argv[i], "userpresence=", 13) == 0) {
       sscanf(argv[i], "userpresence=%d", &cfg->userpresence);
     } else if (strncmp(argv[i], "userverification=", 17) == 0) {
@@ -111,6 +113,7 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t *cfg) {
   debug_dbg(cfg, "alwaysok=%d", cfg->alwaysok);
   debug_dbg(cfg, "sshformat=%d", cfg->sshformat);
   debug_dbg(cfg, "expand=%d", cfg->expand);
+  debug_dbg(cfg, "allowauthtok=%d", cfg->allowauthtok);
   debug_dbg(cfg, "authfile=%s", cfg->auth_file ? cfg->auth_file : "(null)");
   debug_dbg(cfg, "authpending_file=%s",
             cfg->authpending_file ? cfg->authpending_file : "(null)");

--- a/pamu2fcfg/Makefile.am
+++ b/pamu2fcfg/Makefile.am
@@ -9,4 +9,5 @@ pamu2fcfg_SOURCES = pamu2fcfg.c
 pamu2fcfg_SOURCES += readpassphrase.c _readpassphrase.h
 pamu2fcfg_SOURCES += strlcpy.c openbsd-compat.h
 pamu2fcfg_SOURCES += ../util.c ../b64.c ../explicit_bzero.c
+pamu2fcfg_SOURCES += ../authtok.c ../authtok.h
 pamu2fcfg_LDADD = $(LIBFIDO2_LIBS) $(LIBCRYPTO_LIBS)

--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -27,6 +27,7 @@
 
 #include "b64.h"
 #include "util.h"
+#include "authtok.h"
 
 #include "openbsd-compat.h"
 
@@ -46,6 +47,10 @@ struct args {
   int debug;
   int verbose;
   int nouser;
+  int authtok;
+  int pam_userpresence;
+  int pam_userverification;
+  int pam_pinverification;
 };
 
 static fido_cred_t *prepare_cred(const struct args *const args) {
@@ -160,6 +165,14 @@ static fido_cred_t *prepare_cred(const struct args *const args) {
     goto err;
   }
 
+  if (args->authtok) {
+    if ((r = fido_cred_set_extensions(cred, FIDO_EXT_HMAC_SECRET)) != FIDO_OK) {
+      fprintf(stderr, "error: fido_cred_set_extensions (%d) %s\n", r,
+              fido_strerr(r));
+      goto err;
+    }
+  }
+
   ok = 0;
 
 err:
@@ -171,22 +184,27 @@ err:
 }
 
 static int make_cred(const struct args *args, const char *path, fido_dev_t *dev,
-                     fido_cred_t *cred, int devopts) {
+                     fido_cred_t *cred, int devopts,
+                     unsigned char **enc_authtok, size_t *enc_authtok_len) {
   char prompt[BUFSIZE];
-  char pin[BUFSIZE];
+  char authtok[BUFSIZE];
+  char *pin = NULL;
+  fido_opt_t uv;
+  int use_pin;
   int n;
   int r;
+  int retval = -1;
 
   if (path == NULL || dev == NULL || cred == NULL) {
     fprintf(stderr, "%s: args\n", __func__);
-    return -1;
+    goto err;
   }
 
   /* Some form of UV required; built-in UV is available. */
   if (args->user_verification || (devopts & (UV_SET | UV_NOT_REQD)) == UV_SET) {
     if ((r = fido_cred_set_uv(cred, FIDO_OPT_TRUE)) != FIDO_OK) {
       fprintf(stderr, "error: fido_cred_set_uv: %s (%d)\n", fido_strerr(r), r);
-      return -1;
+      goto err;
     }
   }
 
@@ -203,24 +221,73 @@ static int make_cred(const struct args *args, const char *path, fido_dev_t *dev,
        r == FIDO_ERR_PIN_BLOCKED)) {
     n = snprintf(prompt, sizeof(prompt), "Enter PIN for %s: ", path);
     if (n < 0 || (size_t) n >= sizeof(prompt)) {
-      fprintf(stderr, "error: snprintf prompt");
-      return -1;
+      fprintf(stderr, "error: snprintf prompt\n");
+      goto err;
     }
-    if (!readpassphrase(prompt, pin, sizeof(pin), RPP_ECHO_OFF)) {
-      fprintf(stderr, "error: failed to read pin");
-      explicit_bzero(pin, sizeof(pin));
-      return -1;
+    if ((pin = malloc(BUFSIZE)) == NULL) {
+      fprintf(stderr, "error: malloc\n");
+      goto err;
+    }
+    if (!readpassphrase(prompt, pin, BUFSIZE, RPP_ECHO_OFF)) {
+      fprintf(stderr, "error: failed to read pin\n");
+      goto err;
     }
     r = fido_dev_make_cred(dev, cred, pin);
   }
-  explicit_bzero(pin, sizeof(pin));
 
   if (r != FIDO_OK) {
     fprintf(stderr, "error: fido_dev_make_cred (%d) %s\n", r, fido_strerr(r));
-    return -1;
+    goto err;
   }
 
-  return 0;
+  if (args->authtok) {
+    if (!readpassphrase("Enter auth token: ", authtok, sizeof(authtok),
+                        RPP_ECHO_OFF)) {
+      fprintf(stderr, "error: failed to read auth token\n");
+      goto err;
+    }
+
+    if (args->pam_userpresence == 0 && args->no_user_presence) {
+      fprintf(stderr, "error: user presence is required for auth token\n");
+      goto err;
+    }
+
+    if (args->pam_userverification == 1 || args->user_verification == 1) {
+      uv = FIDO_OPT_TRUE;
+    } else if (args->pam_userverification == 0)
+      uv = FIDO_OPT_FALSE;
+    else {
+      uv = FIDO_OPT_OMIT;
+    }
+
+    if (args->pam_pinverification == 1 || args->pin_verification == 1) {
+      if (pin == NULL) {
+        fprintf(stderr,
+                "error: pin verification is required but no pin is found\n");
+        goto err;
+      }
+      use_pin = 1;
+    } else {
+      use_pin = 0;
+    }
+
+    if (!generate_encrypted_authtok(dev, cred, authtok, uv,
+                                    use_pin ? pin : NULL, enc_authtok,
+                                    enc_authtok_len)) {
+      fprintf(stderr, "error: failed to generate encrypted auth token\n");
+      goto err;
+    }
+  }
+
+  retval = 0;
+
+err:
+  explicit_bzero(authtok, BUFSIZE);
+  if (pin) {
+    explicit_bzero(pin, BUFSIZE);
+    free(pin);
+  }
+  return retval;
 }
 
 static int verify_cred(const fido_cred_t *const cred) {
@@ -248,12 +315,15 @@ static int verify_cred(const fido_cred_t *const cred) {
 }
 
 static int print_authfile_line(const struct args *const args,
-                               const fido_cred_t *const cred) {
+                               const fido_cred_t *const cred,
+                               const unsigned char *enc_authtok,
+                               size_t enc_authtok_len) {
   const unsigned char *kh = NULL;
   const unsigned char *pk = NULL;
   const char *user = NULL;
   char *b64_kh = NULL;
   char *b64_pk = NULL;
+  char *b64_enc_authtok = NULL;
   size_t kh_len;
   size_t pk_len;
   int ok = -1;
@@ -296,17 +366,26 @@ static int print_authfile_line(const struct args *const args,
     printf("%s", user);
   }
 
-  printf(":%s,%s,%s,%s%s%s", args->resident ? "*" : b64_kh, b64_pk,
+  if (args->authtok) {
+    if (!b64_encode(enc_authtok, enc_authtok_len, &b64_enc_authtok)) {
+      fprintf(stderr, "error: failed to encode PAM auth token\n");
+      goto err;
+    }
+  }
+
+  printf(":%s,%s,%s,%s%s%s,%s", args->resident ? "*" : b64_kh, b64_pk,
          cose_string(fido_cred_type(cred)),
          !args->no_user_presence ? "+presence" : "",
          args->user_verification ? "+verification" : "",
-         args->pin_verification ? "+pin" : "");
+         args->pin_verification ? "+pin" : "",
+         args->authtok ? b64_enc_authtok : "*");
 
   ok = 0;
 
 err:
   free(b64_kh);
   free(b64_pk);
+  free(b64_enc_authtok);
 
   return ok;
 }
@@ -369,6 +448,8 @@ static void parse_args(int argc, char *argv[], struct args *args) {
     { "verbose",           no_argument,       NULL, 'v'         },
     { "username",          required_argument, NULL, 'u'         },
     { "nouser",            no_argument,       NULL, 'n'         },
+    { "authtok",           no_argument,       NULL, 'a'         },
+    { "pam-arguments",     required_argument, NULL, 'p'         },
     { 0,                   0,                 0,    0           }
   };
   const char *usage =
@@ -395,11 +476,21 @@ static void parse_args(int argc, char *argv[], struct args *args) {
 "                             defaults to the current user name\n"
 "  -n, --nouser             Print only registration information (key handle,\n"
 "                             public key, and options), useful for appending\n"
+"  -a, --authtok            Read a PAM auth token (usually a password) that\n"
+"                             should be decrypted during authentication\n"
+"  -p, --pam-arguments      The arguments passed to the pam module, used for\n"
+"                             encryption key generation when --authtok is set\n"
 "\n"
 "Report bugs at <" PACKAGE_BUGREPORT ">.\n";
   /* clang-format on */
+  char *saveptr = NULL;
+  char *arg;
 
-  while ((c = getopt_long(argc, argv, "ho:i:t:rPNVdvu:n", options, NULL)) !=
+  args->pam_userpresence = -1;
+  args->pam_userverification = -1;
+  args->pam_pinverification = -1;
+
+  while ((c = getopt_long(argc, argv, "ho:i:t:rPNVdvu:nap:", options, NULL)) !=
          -1) {
     switch (c) {
       case 'h':
@@ -438,6 +529,22 @@ static void parse_args(int argc, char *argv[], struct args *args) {
       case 'n':
         args->nouser = 1;
         break;
+      case 'a':
+        args->authtok = 1;
+        break;
+      case 'p':
+        arg = strtok_r(optarg, " ", &saveptr);
+        while (arg != NULL) {
+          if (strncmp(arg, "userpresence=", 13) == 0) {
+            sscanf(arg, "userpresence=%d", &args->pam_userpresence);
+          } else if (strncmp(arg, "userverification=", 17) == 0) {
+            sscanf(arg, "userverification=%d", &args->pam_userverification);
+          } else if (strncmp(arg, "pinverification=", 16) == 0) {
+            sscanf(arg, "pinverification=%d", &args->pam_pinverification);
+          }
+          arg = strtok_r(NULL, " ", &saveptr);
+        }
+        break;
       case OPT_VERSION:
         printf("pamu2fcfg " PACKAGE_VERSION "\n");
         exit(EXIT_SUCCESS);
@@ -463,6 +570,8 @@ int main(int argc, char *argv[]) {
   size_t ndevs = 0;
   int devopts = 0;
   int r;
+  unsigned char *enc_authtok = NULL;
+  size_t enc_authtok_len;
 
   parse_args(argc, argv, &args);
   fido_init(args.debug ? FIDO_DEBUG : 0);
@@ -555,8 +664,10 @@ int main(int argc, char *argv[]) {
   if ((cred = prepare_cred(&args)) == NULL)
     goto err;
 
-  if (make_cred(&args, path, dev, cred, devopts) != 0 ||
-      verify_cred(cred) != 0 || print_authfile_line(&args, cred) != 0)
+  if (make_cred(&args, path, dev, cred, devopts, &enc_authtok,
+                &enc_authtok_len) != 0 ||
+      verify_cred(cred) != 0 ||
+      print_authfile_line(&args, cred, enc_authtok, enc_authtok_len) != 0)
     goto err;
 
   exit_code = EXIT_SUCCESS;
@@ -567,6 +678,10 @@ err:
   fido_dev_info_free(&devlist, ndevs);
   fido_cred_free(&cred);
   fido_dev_free(&dev);
+
+  if (enc_authtok) {
+    free(enc_authtok);
+  }
 
   exit(exit_code);
 }

--- a/util.h
+++ b/util.h
@@ -36,6 +36,7 @@ typedef struct {
   int pinverification;
   int sshformat;
   int expand;
+  int allowauthtok;
   const char *auth_file;
   const char *authpending_file;
   const char *origin;
@@ -50,6 +51,7 @@ typedef struct {
   char *keyHandle;
   char *coseType;
   char *attributes;
+  char *enc_authtok;
   int old_format;
 } device_t;
 


### PR DESCRIPTION
Add support for storing an encrypted password in u2f_keys. During authentication, the password is decrypted and passed to PAM for other PAM modules.

**Problem**

When logging in with pam_u2f as a single factor, gnome-keyring cannot be auto-unlocked. This is because no password was provided during authentication, but gnome-keyring requires the user password to decrypt its database. Another user reported the same problem in #283.

**Solution**

This PR allows pamu2fcfg to optionally store a password for each authenticator. During authentication, pam_u2f retrieves the password and pass it to PAM as `PAM_AUTHTOK`. Subsequent PAM modules such as pam_gnome_keyring will use the password in `PAM_AUTHTOK` to auto-unlock the keyring.

Passwords are encrypted with AES-256-GCM and stored in the u2f_key file, along with an HMAC salt. The AES encryption key is derived using the FIDO2 HMAC-SECRET extension.

New arguments added:
  - pam_u2f:
    -  `allowauthtok`: an optional argument that enables this feature.
  - pamu2fcfg:
    -  `-a, --authtok`: an optional flag to prompt the user for a password to be stored.
    - `-p, --pam-arguments=STRING`: an optional argument that specifies the arguments passed to pam_u2f. This is used to ensure users are authenticated in the same way when getting the HMAC secret.

**Next steps**

Update the documentation for this feature.