### PR TITLE
Allow concatenating u2f_keys

### DIFF
--- a/util.c
+++ b/util.c
@@ -230,13 +230,8 @@ static int parse_native_format(const cfg_t *cfg, const char *username,
     if (s_user && strcmp(username, s_user) == 0) {
       debug_dbg(cfg, "Matched user: %s", s_user);
 
-      // only keep last line for this user
-      for (i = 0; i < *n_devs; i++) {
-        reset_device(&devices[i]);
-      }
-      *n_devs = 0;
-
-      i = 0;
+      // keep all lines each user, concatenating later auth patterns
+      i = *n_devs;
       while ((s_credential = strtok_r(NULL, ":", &saveptr))) {
         if ((*n_devs)++ > cfg->max_devs - 1) {
           *n_devs = cfg->max_devs;


### PR DESCRIPTION
The u2f_keys parsing is pretty harsh and requires sed or manual editing, making it unfriendly to scripts.

Recall the format is:

```
<username>:<cose>:<pubkey>...:<cose2>:<pubkey2>:...
```

If the same username appears more than once then the prior lines are ignored (well, parsed by later discarded). Instead, just allow separate lines. In addition to being backward compatible, there is a nice sysadmin-friendly behavior allowing concatenation.  Ignore the obvious bash code nits, but effectively allowing:

```
pam_u2fconfig -u user >> $u2f_keys_file
# or perhaps a setup that has already collected auth info
cat auth_tokens/user/*  >> /var/yubico/u2f_keys
```