### PR TITLE
Auditability: log U2F public key and index in auth file on success

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,11 +45,11 @@ AM_CONDITIONAL([ENABLE_FUZZING], [test "$enable_fuzzing" = "yes"])
 
 AC_CHECK_HEADERS([security/pam_appl.h], [],
   [AC_MSG_ERROR([[PAM header files not found, install libpam-dev.]])])
-AC_CHECK_HEADERS([security/pam_modules.h security/pam_modutil.h security/openpam.h], [], [],
+AC_CHECK_HEADERS([security/pam_modules.h security/pam_modutil.h security/pam_ext.h security/openpam.h], [], [],
   [#include <sys/types.h>
 #include <security/pam_appl.h>])
 AC_CHECK_LIB([pam], [pam_start])
-AC_CHECK_FUNCS([pam_modutil_drop_priv openpam_borrow_cred])
+AC_CHECK_FUNCS([pam_modutil_drop_priv openpam_borrow_cred pam_syslog])
 
 case "$host" in
      *darwin*)  PAMDIR="/usr/lib/pam";;

--- a/util.c
+++ b/util.c
@@ -22,6 +22,10 @@
 #include <string.h>
 #include <arpa/inet.h>
 
+#ifdef HAVE_SECURITY_PAM_EXT_H
+#include <security/pam_ext.h>
+#endif
+
 #include "b64.h"
 #include "debug.h"
 #include "util.h"
@@ -1483,6 +1487,9 @@ int do_manual_authentication(const cfg_t *cfg, const device_t *devices,
 
     r = fido_assert_verify(assert[i], 0, pk[i].type, pk[i].ptr);
     if (r == FIDO_OK) {
+#ifdef HAVE_PAM_SYSLOG
+      pam_syslog(pamh, LOG_INFO, "Successful FIDO authentication with publicKey %s (idx %u)", devices[i].publicKey, i);
+#endif
       retval = PAM_SUCCESS;
       break;
     }


### PR DESCRIPTION
For users with many auth keys it is absolutely necessary to capture which key allowed the log in to proceed, thus making the use of yubikeys auditable. This PR uses `pam_syslog` to capture INFO of the public key used to allow log in when said function is available (on Linux generally).