### PR TITLE
ci: simplify macos build, fix codeql workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 8 * * 6'
 
+permissions:
+  security-events: write
+
 jobs:
   CodeQL-Build:
 

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: dependencies
-      run: brew install check cmake help2man mandoc openssl@1.1 pkg-config automake
+      run: brew install check cmake help2man libfido2 mandoc pkg-config automake
     - name: build
       env:
         CC: ${{ matrix.cc }}

--- a/build-aux/ci/build-osx.sh
+++ b/build-aux/ci/build-osx.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-# Link to same OpenSSL version as libfido2.
+# Link to the same OpenSSL version as libfido2.
 OPENSSL="$(brew deps --installed libfido2 | grep openssl)"
 LIBFIDO2_PKGCONF="$(brew --prefix libfido2)/lib/pkgconfig"
 OPENSSL_PKGCONF="$(brew --prefix "${OPENSSL}")/lib/pkgconfig"
@@ -10,3 +10,4 @@ export PKG_CONFIG_PATH="${LIBFIDO2_PKGCONF}:${OPENSSL_PKGCONF}"
 ./autogen.sh
 ./configure --disable-silent-rules --disable-man
 make -j $(sysctl -n hw.logicalcpu)
+make check

--- a/build-aux/ci/build-osx.sh
+++ b/build-aux/ci/build-osx.sh
@@ -1,30 +1,12 @@
 #!/usr/bin/env bash
 set -ex
 
-BUILDROOT="$(git rev-parse --show-toplevel)"
+# Link to same OpenSSL version as libfido2.
+OPENSSL="$(brew deps --installed libfido2 | grep openssl)"
+LIBFIDO2_PKGCONF="$(brew --prefix libfido2)/lib/pkgconfig"
+OPENSSL_PKGCONF="$(brew --prefix "${OPENSSL}")/lib/pkgconfig"
+export PKG_CONFIG_PATH="${LIBFIDO2_PKGCONF}:${OPENSSL_PKGCONF}"
 
-pushd "/tmp" &>/dev/null
-  # Build and install libcbor
-  git clone https://github.com/pjk/libcbor
-  pushd "/tmp/libcbor" &>/dev/null
-    git checkout v0.5.0
-    cmake -Bbuild -H.
-    cmake --build build -- --jobs=2 VERBOSE=1
-    sudo make -j $(sysctl -n hw.logicalcpu) -C build install
-  popd &>/dev/null
-
-  # Build and install libfido2
-  export PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig
-  git clone https://github.com/Yubico/libfido2
-  pushd "/tmp/libfido2" &>/dev/null
-    cmake -Bbuild -H.
-    cmake --build build -- --jobs=2 VERBOSE=1
-    sudo make -j $(sysctl -n hw.logicalcpu) -C build install
-  popd &>/dev/null
-popd &>/dev/null
-
-pushd "$BUILDROOT" &>/dev/null
-  ./autogen.sh
-  ./configure --disable-silent-rules --disable-man
-  make -j $(sysctl -n hw.logicalcpu)
-popd &>/dev/null
+./autogen.sh
+./configure --disable-silent-rules --disable-man
+make -j $(sysctl -n hw.logicalcpu)


### PR DESCRIPTION
`brew` has for some time packaged libfido2. We can use those builds to
simplify our pipeline. Ensure linking to the same OpenSSL version as
libfido2 through `brew deps`.

While here, fix CodeQL workflow permissions.