### PR TITLE
Fix (harmless) memory leaks & replace magic number with constant

### DIFF
--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -467,13 +467,13 @@ int main(int argc, char *argv[]) {
   parse_args(argc, argv, &args);
   fido_init(args.debug ? FIDO_DEBUG : 0);
 
-  devlist = fido_dev_info_new(64);
+  devlist = fido_dev_info_new(DEVLIST_LEN);
   if (!devlist) {
     fprintf(stderr, "error: fido_dev_info_new failed\n");
     goto err;
   }
 
-  r = fido_dev_info_manifest(devlist, 64, &ndevs);
+  r = fido_dev_info_manifest(devlist, DEVLIST_LEN, &ndevs);
   if (r != FIDO_OK) {
     fprintf(stderr, "Unable to discover device(s), %s (%d)\n", fido_strerr(r),
             r);
@@ -489,7 +489,7 @@ int main(int argc, char *argv[]) {
       fflush(stderr);
       sleep(FREQUENCY);
 
-      r = fido_dev_info_manifest(devlist, 64, &ndevs);
+      r = fido_dev_info_manifest(devlist, DEVLIST_LEN, &ndevs);
       if (r != FIDO_OK) {
         fprintf(stderr, "\nUnable to discover device(s), %s (%d)",
                 fido_strerr(r), r);

--- a/util.c
+++ b/util.c
@@ -1155,13 +1155,13 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
 #endif
   memset(&pk, 0, sizeof(pk));
 
-  devlist = fido_dev_info_new(64);
+  devlist = fido_dev_info_new(DEVLIST_LEN);
   if (!devlist) {
     debug_dbg(cfg, "Unable to allocate devlist");
     goto out;
   }
 
-  r = fido_dev_info_manifest(devlist, 64, &ndevs);
+  r = fido_dev_info_manifest(devlist, DEVLIST_LEN, &ndevs);
   if (r != FIDO_OK) {
     debug_dbg(cfg, "Unable to discover device(s), %s (%d)", fido_strerr(r), r);
     goto out;
@@ -1171,7 +1171,7 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
 
   debug_dbg(cfg, "Device max index is %zu", ndevs);
 
-  authlist = calloc(64 + 1, sizeof(fido_dev_t *));
+  authlist = calloc(DEVLIST_LEN + 1, sizeof(fido_dev_t *));
   if (!authlist) {
     debug_dbg(cfg, "Unable to allocate authenticator list");
     goto out;
@@ -1267,13 +1267,13 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
 
     fido_dev_info_free(&devlist, ndevs);
 
-    devlist = fido_dev_info_new(64);
+    devlist = fido_dev_info_new(DEVLIST_LEN);
     if (!devlist) {
       debug_dbg(cfg, "Unable to allocate devlist");
       goto out;
     }
 
-    r = fido_dev_info_manifest(devlist, 64, &ndevs);
+    r = fido_dev_info_manifest(devlist, DEVLIST_LEN, &ndevs);
     if (r != FIDO_OK) {
       debug_dbg(cfg, "Unable to discover device(s), %s (%d)", fido_strerr(r),
                 r);

--- a/util.h
+++ b/util.h
@@ -21,6 +21,8 @@
 #define DEFAULT_ORIGIN_PREFIX "pam://"
 #define SSH_ORIGIN "ssh:"
 
+#define DEVLIST_LEN 64
+
 typedef struct {
   unsigned max_devs;
   int manual;


### PR DESCRIPTION
* Add preprocessor constant `DEVLIST_ALLOC_INITIAL_LEN` to replace magic number 64 in allocations of device info list. The named constant expresses meaning and makes bugs & memory-leaks due to missed code changes less likely, should one decide to change the number of slots to allocate in the device info list.

* Fix the same errorneous code in freeing the device info list at three points in the code:
Calling `fido_dev_info_free` with length argument `ndevs` deallocates only the filled entries of the device info list, while leaving the empty entries dangling. This does not seem to leak any data, though.
The commit fixes the code to actually deallocate the whole array.