### PR TITLE
Add CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,102 @@
+# Copyright (c) 2024 Yubico AB. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the COPYING file.
+# SPDX-License-Identifier: BSD-2-Clause
+cmake_minimum_required(VERSION 3.12)
+
+project(pam_u2f VERSION 1.3.1 LANGUAGES C)
+
+# Set C macros
+add_compile_definitions(PACKAGE_BUGREPORT="https://github.com/Yubico/pam-u2f/issues")
+add_compile_definitions(PACKAGE_VERSION="${CMAKE_PROJECT_VERSION}")
+
+include(GNUInstallDirs)
+include(FindPkgConfig)
+include(CheckIncludeFile)
+include(CheckSymbolExists)
+include(CheckFunctionExists)
+
+option(BUILD_TESTS "Build the tests" ON)
+option(BUILD_MANPAGES "Build man pages" ON)
+
+add_compile_options(-Wall)
+add_compile_options(-Wbad-function-cast)
+add_compile_options(-Wcast-qual)
+add_compile_options(-Wconversion)
+add_compile_options(-Wextra)
+add_compile_options(-Wformat=2)
+add_compile_options(-Wimplicit-fallthrough)
+add_compile_options(-Wmissing-declarations)
+add_compile_options(-Wmissing-prototypes)
+add_compile_options(-Wmissing-prototypes)
+add_compile_options(-Wnull-dereference)
+add_compile_options(-Wshadow)
+add_compile_options(-Wstrict-prototypes)
+add_compile_options(-Wwrite-strings)
+add_compile_options(-pedantic-errors)
+add_compile_options(-pedantic)
+
+pkg_search_module(FIDO2 REQUIRED libfido2)
+pkg_search_module(CRYPTO REQUIRED libcrypto)
+pkg_search_module(PAM REQUIRED pam)
+
+include_directories(.)
+include_directories(${FIDO2_INCLUDE_DIRS})
+include_directories(${CRYPTO_INCLUDE_DIRS})
+include_directories(${PAM_INCLUDE_DIRS})
+
+link_directories(${FIDO2_LIBRARY_DIRS})
+link_directories(${CRYPTO_LIBRARY_DIRS})
+link_directories(${PAM_LIBRARY_DIRS})
+
+
+set(CMAKE_REQUIRED_LIBRARIES
+        ${FIDO2_LIBRARIES}
+        ${CRYPTO_LIBRARIES}
+        ${PAM_LIBRARIES}
+)
+check_include_file(unistd.h HAVE_UNISTD_H)
+check_symbol_exists(pam_modutil_drop_priv "/usr/include/security/pam_modutil.h" HAVE_PAM_MODUTIL_DROP_PRIV)
+check_symbol_exists(openpam_borrow_cred  "security/openpam.h" HAVE_OPENPAM_BORROW_CRED)
+
+set(CHECK_VARIABLES
+        HAVE_UNISTD_H
+        HAVE_PAM_MODUTIL_DROP_PRIV
+        HAVE_OPENPAM_BORROW_CRED
+)
+
+foreach(v ${CHECK_VARIABLES})
+    if (${v})
+        add_compile_definitions(${v})
+    endif()
+endforeach()
+
+
+add_subdirectory(pamu2fcfg)
+
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+if(BUILD_MANPAGES)
+    add_subdirectory(man)
+endif()
+
+
+set(PAM_U2F_SOURCES
+        pam-u2f.c
+        b64.c
+        debug.c
+        expand.c
+        explicit_bzero.c
+        util.c
+)
+add_library(pam_u2f SHARED ${PAM_U2F_SOURCES})
+set_target_properties(pam_u2f PROPERTIES OUTPUT_NAME pam_u2f)
+
+target_link_libraries(pam_u2f ${FIDO2_LIBRARIES} ${CRYPTO_LIBRARIES} ${PAM_LIBRARIES})
+
+install(TARGETS pam_u2f
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Copyright (c) 2024 Yubico AB. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+# SPDX-License-Identifier: BSD-2-Clause
+
+find_program(GZIP_PATH gzip)
+find_program(A2X_PATH NAMES a2x a2x.py)
+set(A2X_OPTS
+        -D ${CMAKE_CURRENT_BINARY_DIR}
+        -f manpage
+        -L
+        -a revdate="Version ${CMAKE_PROJECT_VERSION}"
+)
+
+set(MAN_NAMES pamu2fcfg.1 pam_u2f.8)
+
+# man_gen
+foreach(n ${MAN_NAMES})
+    set(f ${CMAKE_CURRENT_SOURCE_DIR}/${n}.txt)
+    add_custom_command(OUTPUT ${n}
+            COMMAND ${A2X_PATH} ${A2X_OPTS} ${f}
+            DEPENDS ${f})
+    list(APPEND MAN_FILES ${n})
+endforeach()
+
+# man_gzip
+foreach(f ${MAN_FILES})
+    add_custom_command(OUTPUT ${f}.gz
+            COMMAND gzip -cn ${f} > ${f}.gz
+            DEPENDS ${f})
+    list(APPEND GZ_FILES ${f}.gz)
+endforeach()
+
+add_custom_target(man_gen DEPENDS ${MAN_FILES})
+add_custom_target(man_gzip DEPENDS ${GZ_FILES})
+add_custom_target(man ALL)
+
+if(GZIP_PATH)
+    add_dependencies(man_gzip man_gen)
+    add_dependencies(man man_gzip)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pamu2fcfg.1.gz DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pam_u2f.8.gz DESTINATION "${CMAKE_INSTALL_MANDIR}/man8")
+else()
+    add_dependencies(man man_gen)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pamu2fcfg.1.gz DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pam_u2f.8.gz DESTINATION "${CMAKE_INSTALL_MANDIR}/man8")
+endif()

--- a/pamu2fcfg/CMakeLists.txt
+++ b/pamu2fcfg/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) 2024 Yubico AB. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the COPYING file.
+# SPDX-License-Identifier: BSD-2-Clause
+
+include_directories(.)
+
+set(PAMU2FCFG_SOURCES
+        pamu2fcfg.c
+        readpassphrase.c
+        strlcpy.c
+        ../util.c
+        ../b64.c
+        ../explicit_bzero.c
+)
+
+add_executable(pamu2fcfg
+        ${PAMU2FCFG_SOURCES}
+)
+
+target_link_libraries(pamu2fcfg ${FIDO2_LIBRARIES} ${CRYPTO_LIBRARIES} ${PAM_LIBRARIES})
+
+install(TARGETS pamu2fcfg
+        DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Yubico AB. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the COPYING file.
+# SPDX-License-Identifier: BSD-2-Clause
+
+macro(add_check NAME SOURCES LIB)
+    add_executable(${NAME} ${SOURCES})
+    add_test(NAME ${NAME} COMMAND ${NAME} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+    target_link_libraries(${NAME} ${LIB})
+endmacro()
+
+add_check(dlsym_check dlsym_check.c pam_u2f)
+add_check(expand expand.c pam_u2f)
+add_check(get_devices get_devices.c pam_u2f)
+
+set_property(TEST dlsym_check PROPERTY ENVIRONMENT "PAM_U2F_MODULE=${CMAKE_BINARY_DIR}/libpam_u2f.so")


### PR DESCRIPTION
After the xz fallout, concerns were raised on the Fedora devel mailing list regarding the autotools build system. Many developers and package maintainers are unfamiliar with autotools, and its use of obscure m4 scripts makes it difficult to understand what the scripts are doing. This complexity increases the risk of backdoors going unnoticed.

This PR implements CMake as an alternative build system (or completely replaces autotools). CMake is a modern relatively easy to understand build system and is already in use by other Yubico projects.

At the moment this PR only implements support for building pam-u2f, testing and man-pages. The following is still missing:

- [ ] fuzzing option
- [ ] static/shared build option
- [ ] pam-dir configuration
- [ ] Apple/macos support
- [ ] ...?

These features may be implemented in future pull requests or in this one. 

Since this is a major change that doesn't benefit end users I would like some confirmation as to whether this would ever be merged before continuing with this work. I completely understand if you, the maintainers, are satisfied with autotools and prefer not to maintain two build systems or replace it at this stage of the project's maturity.