### PR TITLE
enable session operations

### DIFF
--- a/export.sym
+++ b/export.sym
@@ -1,2 +1,4 @@
 pam_sm_authenticate
 pam_sm_setcred
+pam_sm_open_session
+pam_sm_close_session

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -4,6 +4,7 @@
 
 /* Define which PAM interfaces we provide */
 #define PAM_SM_AUTH
+#define PAM_SM_SESSION
 
 /* Include PAM headers */
 #include <security/pam_appl.h>
@@ -429,6 +430,20 @@ done:
   cfg->debug_file = DEFAULT_DEBUG_FILE;
 
   return retval;
+}
+
+PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc,
+                                   const char **argv) {
+  return pam_sm_authenticate(pamh, flags, argc, argv);
+}
+
+PAM_EXTERN int pam_sm_close_session(pam_handle_t *pamh, int flags, int argc,
+                                    const char **argv) {
+  (void) pamh;
+  (void) flags;
+  (void) argc;
+  (void) argv;
+  return PAM_SUCCESS;
 }
 
 PAM_EXTERN int pam_sm_setcred(pam_handle_t *pamh, int flags, int argc,

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -434,7 +434,16 @@ done:
 
 PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc,
                                    const char **argv) {
-  return pam_sm_authenticate(pamh, flags, argc, argv);
+  int retval;
+
+  retval = pam_sm_authenticate(pamh, flags, argc, argv);
+
+  if (retval != PAM_SUCCESS) {
+    // pam_sm_open_session() requires only PAM_SUCCESS or PAM_SESSION_ERR be returned.
+    retval = PAM_SESSION_ERR;
+  }
+
+  return retval;
 }
 
 PAM_EXTERN int pam_sm_close_session(pam_handle_t *pamh, int flags, int argc,

--- a/tests/bionic/Dockerfile
+++ b/tests/bionic/Dockerfile
@@ -1,6 +1,4 @@
 FROM ubuntu:bionic
-COPY . /pam-u2f
-WORKDIR /pam-u2f
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -qq update
 RUN apt-get -qq upgrade
@@ -10,6 +8,8 @@ RUN apt-get -qq update
 RUN apt-get install -qq libudev-dev libssl-dev libfido2-dev
 RUN apt-get install -qq build-essential autoconf automake libtool pkg-config
 RUN apt-get install -qq libpam-dev pamtester
+COPY . /pam-u2f
+WORKDIR /pam-u2f
 RUN autoreconf -i .
 RUN ./configure --disable-man
 RUN make clean all install

--- a/tests/bionic/run.sh
+++ b/tests/bionic/run.sh
@@ -57,7 +57,16 @@ run_user_verification_tests() {
 	pamtester dummy root authenticate
 }
 
+run_session_tests() {
+	echo "session required pam_u2f.so" > /etc/pam.d/dummy
+	cp /tmp/es256 ~/.config/Yubico/u2f_keys
+	pamtester dummy root open_session
+	pamtester dummy root close_session
+}
+
+
 create_keys
 run_tests
 run_user_presence_tests
 run_user_verification_tests
+run_session_tests

--- a/tests/bionic/run.sh
+++ b/tests/bionic/run.sh
@@ -62,8 +62,15 @@ run_session_tests() {
 	cp /tmp/es256 ~/.config/Yubico/u2f_keys
 	pamtester dummy root open_session
 	pamtester dummy root close_session
-}
 
+	rm ~/.config/Yubico/u2f_keys
+	if pamtester dummy root open_session > /dev/null 2>&1 ; then
+		>&2 echo Error: unexpectingly succeeding opening session when it shouldn\'t.
+		exit 1
+	else
+		echo Successfully prevented opening session because no key configured.
+	fi
+}
 
 create_keys
 run_tests

--- a/tests/dlsym_check.c
+++ b/tests/dlsym_check.c
@@ -16,6 +16,8 @@ int main(void) {
   assert((module = dlopen(path, RTLD_NOW)) != NULL);
   assert(dlsym(module, "pam_sm_authenticate") != NULL);
   assert(dlsym(module, "pam_sm_setcred") != NULL);
+  assert(dlsym(module, "pam_sm_open_session") != NULL);
+  assert(dlsym(module, "pam_sm_close_session") != NULL);
   assert(dlsym(module, "nonexistent") == NULL);
   assert(dlclose(module) == 0);
 


### PR DESCRIPTION
I wonder if you would be interested in following functionality:

For sudo, it would be nice if the pam_u2f module can be used for PAM session operations as well, for two reasons:

- sudo by default authenticates against the user executing sudo, instead of the target user. When adding pam_u2f as a session operation, the session will be enforced for the target user as well.
- sudo caches credentials by default for 15 minutes. If this is the case, it will skip any authentication with pam altogether, however sessions are still executed. This opens the possibility to have only the password to be entered once per 15 minutes, but still assert consent easily with Fido for every sudo action. This feature is highly wanted for my current situation.

However, I can imagine the PAM session is not the right place for performing u2f validation actions. I'm no PAM expert at all. However failing the session action while it is set to required, certainly aborts the session, which is what is wanted.

If interested, feel free to comment on the code I added or commits I made, or suggest another solution.
I didn't find any detailed tests other than the ones in tests/bionic/ , which were easy to extend, I found out however they are not run in the Github Actions pipeline.