### PR TITLE
Alter nouserok behaviour from PAM_SUCCESS to PAM_IGNORE

### DIFF
--- a/README
+++ b/README
@@ -161,9 +161,9 @@ disable this functionality, like so: `authpending_file=`. Default value:
 /var/run/user/$UID/pam-u2f-authpending
 
 nouserok::
-Set to enable authentication attempts to succeed even if the user
-trying to authenticate is not found inside `authfile` or if `authfile`
-is missing/malformed.
+Set to allow authentication attempts to continue to other authentication
+methods even if the user trying to authenticate is not found inside 
+`authfile` or if `authfile` is missing/malformed. (returns PAM_IGNORE)
 
 openasuser::
 Setuid to the authenticating user when opening the authfile. Useful

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -320,7 +320,7 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
     if (cfg->nouserok) {
       debug_dbg(cfg, "Found no devices but nouserok specified. Skipping "
                      "authentication");
-      retval = PAM_SUCCESS;
+      retval = PAM_IGNORE;
       goto done;
     } else if (retval != 1) {
       debug_dbg(cfg, "Unable to get devices from authentication file");


### PR DESCRIPTION
Alter nouserok behaviour from PAM_SUCCESS to PAM_IGNORE so that other
authentication methods can be tried rather than potentially allowing access
before a user account has been provisioned with a FIDO key.
