### PR TITLE
Create interactive prompt for use when fido device is not detected

### DIFF
--- a/README
+++ b/README
@@ -186,6 +186,11 @@ interactive::
 Set to prompt a message and wait before testing the presence of a FIDO
 device. Recommended if your device doesn't have a tactile trigger.
 
+interactivenodevice::
+Set to prompt a message and wait if no FIDO device is detected.
+Avoids silent authentication failures at the cost of notifying attackers
+fido devices are used for authentication
+
 [prompt=your prompt here]::
 Set individual prompt message for interactive mode. Watch the square
 brackets around this parameter to get spaces correctly recognized by

--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -59,6 +59,8 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t *cfg) {
       cfg->alwaysok = 1;
     } else if (strcmp(argv[i], "interactive") == 0) {
       cfg->interactive = 1;
+    } else if (strcmp(argv[i], "interactivenodevice") == 0) {
+      cfg->interactivenodevice = 1;
     } else if (strcmp(argv[i], "cue") == 0) {
       cfg->cue = 1;
     } else if (strcmp(argv[i], "nodetect") == 0) {
@@ -100,6 +102,7 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t *cfg) {
   debug_dbg(cfg, "max_devices=%d", cfg->max_devs);
   debug_dbg(cfg, "debug=%d", cfg->debug);
   debug_dbg(cfg, "interactive=%d", cfg->interactive);
+  debug_dbg(cfg, "interactivenodevice=%d", cfg->interactivenodevice);
   debug_dbg(cfg, "cue=%d", cfg->cue);
   debug_dbg(cfg, "nodetect=%d", cfg->nodetect);
   debug_dbg(cfg, "userpresence=%d", cfg->userpresence);

--- a/util.c
+++ b/util.c
@@ -1146,6 +1146,7 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
   struct opts opts;
   struct pk pk;
   char *pin = NULL;
+  int foundauth = 0;
 
   init_opts(&opts);
 #ifndef WITH_FUZZING
@@ -1200,7 +1201,21 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
       goto out;
     }
 
-    if (get_authenticators(cfg, devlist, ndevs, assert,
+    if((cfg->interactivenodevice) && !get_authenticators(cfg, devlist, ndevs, assert,
+                           is_resident(devices[i].keyHandle), authlist))
+    {
+	char *tmp = NULL;
+
+	tmp = converse(pamh, PAM_PROMPT_ECHO_ON,
+		cfg->prompt != NULL ? cfg->prompt : DEFAULT_PROMPT);
+
+	free(tmp);
+    }
+    else
+    {
+	    foundauth = 1;
+    }
+    if (foundauth || get_authenticators(cfg, devlist, ndevs, assert,
                            is_resident(devices[i].keyHandle), authlist)) {
       for (size_t j = 0; authlist[j] != NULL; j++) {
         /* options used during authentication */

--- a/util.h
+++ b/util.h
@@ -31,6 +31,7 @@ typedef struct {
   int openasuser;
   int alwaysok;
   int interactive;
+  int interactivenodevice;
   int cue;
   int nodetect;
   int userpresence;


### PR DESCRIPTION
Create new interactive prompt for use when fido device is not detected to remind the user to plug it in.  While this does have the disadvantage of informing an attacker fido devices are in use some environments might consider this worth while to reduce confusion during the switch to fido authentication.