### PR TITLE
ci: rotate out macos-12, bring in macos-15

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-12, macos-13, macos-14 ]
+        os: [ macos-13, macos-14, macos-15 ]
         cc: [ clang ]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The macos-12 runner is deprecated; macos-15 is in public preview.