### PR TITLE
Fix sign conversion warnings

### DIFF
--- a/expand.c
+++ b/expand.c
@@ -54,7 +54,7 @@ char *expand_variables(const char *str, const char *user) {
           buf_write(&head, &size, value, strlen(value)) != 0) {
         goto fail;
       }
-    } else if (buf_write_byte(&head, &size, *str) != 0) {
+    } else if (buf_write_byte(&head, &size, (uint8_t) *str) != 0) {
       goto fail;
     }
   }

--- a/util.c
+++ b/util.c
@@ -730,7 +730,12 @@ int get_devices_from_authfile(const cfg_t *cfg, const char *username,
 #endif
   }
 
-  opwfile_size = st.st_size;
+  if (st.st_size < 0) {
+    debug_dbg(cfg, "Invalid stat size for %s: %jd", cfg->auth_file,
+              (intmax_t) st.st_size);
+    goto err;
+  }
+  opwfile_size = (size_t) st.st_size;
 
   gpu_ret = getpwuid_r(st.st_uid, &pw_s, buffer, sizeof(buffer), &pw);
   if (gpu_ret != 0 || pw == NULL) {


### PR DESCRIPTION
The `-Wsign-conversion` warning is currently disabled in pam_u2f, due to a conflicting macro in `security/pam_modutil.h` (`PAM_MODUTIL_DEF_PRIVS`). This setting shadowed a couple of warnings, which have been noticed while working on the build system.