### PR TITLE
fuzz: introduce fuzz/fido_fuzz.h

### DIFF
--- a/fuzz/fido_fuzz.h
+++ b/fuzz/fido_fuzz.h
@@ -1,0 +1,15 @@
+/* Copyright (C) 2025 Yubico AB - See COPYING */
+#ifndef FIDO_FUZZ_H
+#define FIDO_FUZZ_H
+
+#include <stdint.h>
+
+/* The following symbols are part of libfido2's fuzzing instrumentation.
+ * The linked libfido2 library must be built with -DFUZZ=1
+ */
+
+extern int prng_up;
+void prng_init(unsigned long);
+uint32_t uniform_random(uint32_t);
+
+#endif /* FIDO_FUZZ_H */

--- a/fuzz/fuzz.h
+++ b/fuzz/fuzz.h
@@ -31,8 +31,4 @@ int unpack_blob(const uint8_t **, size_t *, struct blob *);
 int pack_string(uint8_t **, size_t *, const char *);
 int unpack_string(const uint8_t **, size_t *, char *);
 
-/* part of libfido2's fuzzing instrumentation, requires build with -DFUZZ=1 */
-void prng_init(unsigned long);
-uint32_t uniform_random(uint32_t);
-
 #endif

--- a/fuzz/fuzz_auth.c
+++ b/fuzz/fuzz_auth.c
@@ -12,9 +12,11 @@
 #include <unistd.h>
 
 #include "cfg.h"
+
+#include "fuzz/authfile.h"
+#include "fuzz/fido_fuzz.h"
 #include "fuzz/fuzz.h"
 #include "fuzz/wiredata.h"
-#include "fuzz/authfile.h"
 
 #define MUTATE_SEED 0x01
 #define MUTATE_PARAM 0x02

--- a/fuzz/fuzz_format_parsers.c
+++ b/fuzz/fuzz_format_parsers.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "fuzz/fido_fuzz.h"
 #include "fuzz/fuzz.h"
 #include "util.h"
 

--- a/fuzz/pack.c
+++ b/fuzz/pack.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <arpa/inet.h>
 
+#include "fuzz/fido_fuzz.h"
 #include "fuzz/fuzz.h"
 
 static int do_unpack(const uint8_t **buf, size_t *rem, uint8_t *dst,

--- a/fuzz/wrap.c
+++ b/fuzz/wrap.c
@@ -17,9 +17,8 @@
 
 #include "debug.h"
 #include "drop_privs.h"
+#include "fuzz/fido_fuzz.h"
 #include "fuzz/fuzz.h"
-
-extern int prng_up;
 
 #ifdef HAVE_PAM_MODUTIL_DROP_PRIV
 typedef struct pam_modutil_privs fuzz_privs_t;


### PR DESCRIPTION
A header including the prototypes of the functions we borrow from libfido2 fuzzing instrumentation.

By having them into a separate header we make it simpler the addition of configure-time checks on the availability of these functions.