### PR TITLE
Remove spurious dependency

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,8 +12,7 @@ dlsym_check_LDFLAGS = -ldl $(AM_LDFLAGS)
 
 # XXX move openbsd-compat
 check_PROGRAMS += get_devices
-get_devices_SOURCES = get_devices.c ../pamu2fcfg/strlcpy.c
-get_devices_CPPFLAGS = -I$(srcdir)/../pamu2fcfg
+get_devices_SOURCES = get_devices.c
 get_devices_LDADD = $(top_builddir)/libmodule.la
 
 check_PROGRAMS += expand

--- a/tests/get_devices.c
+++ b/tests/get_devices.c
@@ -13,8 +13,6 @@
 #include <string.h>
 #include "../util.h"
 
-#include "openbsd-compat.h"
-
 static void test_nouserok(const char *username) {
   device_t *dev;
   unsigned ndevs;


### PR DESCRIPTION


```
pam-u2f_public $ git grep strlcpy
configure.ac:AC_CHECK_FUNCS([secure_getenv strlcpy readpassphrase explicit_bzero memset_s])
fuzz/fuzz_auth.c:  /* FIXME: use strlcpy */
pamu2fcfg/Makefile.am:pamu2fcfg_SOURCES += strlcpy.c openbsd-compat.h
pamu2fcfg/openbsd-compat.h:size_t strlcpy(char *, const char *, size_t);
pamu2fcfg/pamu2fcfg.c:    if (strlcpy(origin, args->origin, sizeof(origin)) >= sizeof(origin)) {
pamu2fcfg/pamu2fcfg.c:      fprintf(stderr, "error: strlcpy failed\n");
pamu2fcfg/pamu2fcfg.c:    if ((n = strlcpy(origin, PAM_PREFIX, sizeof(origin))) >= sizeof(origin)) {
pamu2fcfg/pamu2fcfg.c:      fprintf(stderr, "error: strlcpy failed\n");
pamu2fcfg/strlcpy.c:/*  $OpenBSD: strlcpy.c,v 1.11 2006/05/05 15:27:38 millert Exp $    */
pamu2fcfg/strlcpy.c:/* OPENBSD ORIGINAL: lib/libc/string/strlcpy.c */
pamu2fcfg/strlcpy.c:strlcpy(char *dst, const char *src, size_t siz)
```