### PR TITLE
Git trailers

### DIFF
--- a/.github/workflows/check-commit-hooks.yml
+++ b/.github/workflows/check-commit-hooks.yml
@@ -1,0 +1,31 @@
+name: Check commit hooks
+
+on: [push, pull_request]
+
+jobs:
+  commit_msg:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check
+      run: |
+        if [ -n "${GITHUB_BASE_REF}" ]; then
+          # pull request, check head branch against base branch
+          GITHUB_BEFORE="$(git ls-remote origin "${GITHUB_BASE_REF}" | cut -f1)"
+        elif [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+          # workflow triggered from some branch other than main, assume that
+          # the branch will eventually be merged into main
+          GITHUB_BEFORE="$(git ls-remote origin refs/heads/main | cut -f1)"
+        else
+          # main branch, compare against previous state
+          # (jq comes preinstalled on github runners)
+          GITHUB_BEFORE="$(jq -r '.before' "${GITHUB_EVENT_PATH}")"
+        fi
+
+        # github interleaves stderr and stdout, redirect everything to stdout
+        exec 2>&1
+
+        export GIT_TOPLEVEL="$PWD"
+        ./build-aux/ci/check-commit-hooks "${GITHUB_BEFORE}..${GITHUB_REF}"

--- a/build-aux/ci/check-commit-hooks
+++ b/build-aux/ci/check-commit-hooks
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+# Copyright (C) 2025 Yubico AB - See COPYING
+#
+# This script checks that the individual commits within a given revision range
+# respect desired properties.
+
+set -eu
+exec 1>&2
+
+: "${1:?revision range}"
+
+: "${GIT_TOPLEVEL:=$(git rev-parse --show-toplevel)}"
+export GIT_TOPLEVEL
+
+COMMIT_MSG_HOOK="$GIT_TOPLEVEL/contrib/hooks/commit-msg"
+
+check_commit() {
+  git show --pretty='%B' --no-patch "$1" | "$COMMIT_MSG_HOOK"
+} 2>&1
+
+CHECKED=0
+EXVAL=0
+
+for HASH in $(git log --no-merges --oneline --format=%H "$1"); do
+  SUBJECT="$(git show --pretty='%s' --no-patch "$HASH")"
+
+  if ERROR_MSG="$(check_commit "$HASH")"
+  then
+    echo "$HASH (\"$SUBJECT\"): OK"
+  else
+    echo "$HASH (\"$SUBJECT\"): NOK"
+    printf "%s\n" "$ERROR_MSG" | sed "s/^/  Error:   /"
+    printf "\n"
+
+    EXVAL=1
+  fi
+
+  CHECKED=$((CHECKED + 1))
+done
+
+echo "Checked $CHECKED commits"
+exit $EXVAL

--- a/contrib/allowed-trailers.txt
+++ b/contrib/allowed-trailers.txt
@@ -1,0 +1,5 @@
+Changelog: added
+Changelog: breaking
+Changelog: security
+Changelog: docs
+Changelog: downstream

--- a/contrib/gen-news
+++ b/contrib/gen-news
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# Copyright (C) 2025 Yubico AB - See COPYING
+#
+# Generate content for the NEWS file from git history.
+#
+# Commits that are relevant for the NEWS file should be marked by
+# means of their "Changelog" trailer (see git-interpret-trailers).
+#
+# A list of allowed values is available in contrib/allowed-trailers.txt
+
+set -eu
+
+if [ -n "${1-}" ]; then
+  range="$1"
+  git rev-list --quiet "$range" --
+else
+  range="$(git describe --abbrev=0 --match 'pam_u2f-*')..HEAD"
+fi
+
+git log \
+  --oneline \
+  --pretty="%(trailers:key=Changelog,valueonly,separator=%x2C): %s" \
+  "$range" |
+sed -n '/^\w\+:/s/^/** /p'

--- a/contrib/hooks-setup
+++ b/contrib/hooks-setup
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+#
+# Copyright (C) 2025 Yubico AB - See COPYING
+#
+# Run this script after cloning the repository to
+# enable the git hooks within this directory.
+
+set -eu
+
+GIT_DIR="$(git rev-parse --git-dir)"
+GIT_HOOKS_DIR="$GIT_DIR/hooks"
+
+GIT_TOPLEVEL="$(git rev-parse --show-toplevel)"
+HOOKS_REPO="$GIT_TOPLEVEL/contrib/hooks"
+
+for h in "$HOOKS_REPO/"*; do
+  ln -vsfr "$HOOKS_REPO/$h" "$GIT_HOOKS_DIR/"
+done

--- a/contrib/hooks/commit-msg
+++ b/contrib/hooks/commit-msg
@@ -11,10 +11,17 @@ exec 1>&2
 # See: git-interpret-trailers(1)
 ALLOWED_TRAILERS="$GIT_TOPLEVEL/contrib/allowed-trailers.txt"
 
-if BAD_TRAILERS="$(
-  git interpret-trailers --only-trailers "$@" |
-  grep -v -f "$ALLOWED_TRAILERS"
-)"; then
+select_trailers() {
+  set - $(sed 's/^/-e/; s/:.*/:/' "$ALLOWED_TRAILERS" | sort -u)
+  grep -F "$@"
+}
+
+bad_trailers() {
+  select_trailers | grep -v -f "$ALLOWED_TRAILERS"
+}
+
+if BAD_TRAILERS="$(git interpret-trailers --only-trailers "$@" | bad_trailers)"
+then
   echo "Invalid git trailers:"
   printf '%s\n' "$BAD_TRAILERS" | sed 's/^/  /'
 

--- a/contrib/hooks/commit-msg
+++ b/contrib/hooks/commit-msg
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+#
+# Copyright (C) 2025 Yubico AB - See COPYING
+
+set -eu
+exec 1>&2
+
+: "${GIT_TOPLEVEL:=$(git rev-parse --show-toplevel)}"
+
+# Check commit message for the presence of required trailers.
+# See: git-interpret-trailers(1)
+ALLOWED_TRAILERS="$GIT_TOPLEVEL/contrib/allowed-trailers.txt"
+
+if BAD_TRAILERS="$(
+  git interpret-trailers --only-trailers "$@" |
+  grep -v -f "$ALLOWED_TRAILERS"
+)"; then
+  echo "Invalid git trailers:"
+  printf '%s\n' "$BAD_TRAILERS" | sed 's/^/  /'
+
+  echo "Note: valid trailers are:"
+  sed 's/^/  /' <"$ALLOWED_TRAILERS";
+
+  exit 1
+fi


### PR DESCRIPTION
We are leveraging git trailers to automate the additions to the NEWS file during release.

Commits having the `Changelog` trailers are checked automatically, to enforce the use of a restricted set of values.

The checks can be used as commit hooks during development.  They're compatible by design.