### PR TITLE
Work-around cmake bug

### DIFF
--- a/cmake/FindPAM.cmake
+++ b/cmake/FindPAM.cmake
@@ -2,19 +2,17 @@
 
 pkg_check_modules(PAM QUIET IMPORTED_TARGET pam)
 
-if (PAM_FOUND)
-	add_library(PAM::PAM ALIAS PkgConfig::PAM)
-else()
+if (NOT PAM_FOUND)
 	find_library(PAM_LINK_LIBRARIES NAMES pam REQUIRED)
 	find_path(PAM_INCLUDE_DIRS NAMES security/pam_modules.h)
-
-	add_library(PAM::PAM UNKNOWN IMPORTED)
-
-	set_target_properties(PAM::PAM PROPERTIES
-		IMPORTED_LOCATION "${PAM_LINK_LIBRARIES}"
-		INTERFACE_INCLUDE_DIRECTORIES "${PAM_INCLUDE_DIRS}"
-	)
 endif()
+
+add_library(PAM::PAM UNKNOWN IMPORTED)
+
+set_target_properties(PAM::PAM PROPERTIES
+	IMPORTED_LOCATION "${PAM_LINK_LIBRARIES}"
+	INTERFACE_INCLUDE_DIRECTORIES "${PAM_INCLUDE_DIRS}"
+)
 
 find_package_handle_standard_args(PAM
 	REQUIRED_VARS PAM_LINK_LIBRARIES PAM_INCLUDE_DIRS


### PR DESCRIPTION
As it turns out, the cmake version shipped with ubuntu 24.04 can not correctly handle ALIAS targets as CMAKE_REQUIRED_LIBRARIES.

We didn't realize before because the ubuntu 24.04 vm available for github actions ships another version of cmake, (3.31.5 instead of 3.28)