### PR TITLE
Remove debug_file=

### DIFF
--- a/README
+++ b/README
@@ -149,15 +149,7 @@ Test your configuration thoroughly before closing the root shell.
 
 [horizontal]
 debug::
-Enables debug output
-
-debug_file::
-Filename to write debugging messages to. **If this file is missing,
-nothing will be logged**. This regular file **has to be created by the
-user** or **must exist and be a regular file** for anything getting
-logged to it. It is not created by pam-u2f on purpose (for security
-considerations). This filename may be alternatively set to "stderr"
-(default), "stdout", or "syslog".
+Enables debug output to syslog.
 
 origin=origin::
 Set the relying party ID for the FIDO authentication procedure. If no

--- a/cfg.c
+++ b/cfg.c
@@ -18,10 +18,6 @@
 static void cfg_load_arg_debug(cfg_t *cfg, const char *arg) {
   if (strcmp(arg, "debug") == 0)
     cfg->debug = 1;
-  else if (strncmp(arg, "debug_file=", strlen("debug_file=")) == 0) {
-    debug_close(cfg->debug_file);
-    cfg->debug_file = debug_open(arg + strlen("debug_file="));
-  }
 }
 
 static void cfg_load_arg(cfg_t *cfg, const char *arg) {
@@ -239,7 +235,6 @@ exit:
 
 static void cfg_reset(cfg_t *cfg) {
   memset(cfg, 0, sizeof(cfg_t));
-  cfg->debug_file = DEFAULT_DEBUG_FILE;
   cfg->userpresence = -1;
   cfg->userverification = -1;
   cfg->pinverification = -1;
@@ -303,7 +298,6 @@ exit:
 }
 
 void cfg_free(cfg_t *cfg) {
-  debug_close(cfg->debug_file);
   free(cfg->defaults_buffer);
   cfg_reset(cfg);
 }

--- a/cfg.h
+++ b/cfg.h
@@ -31,7 +31,6 @@ typedef struct {
   const char *appid;
   const char *prompt;
   const char *cue_prompt;
-  FILE *debug_file;
   char *defaults_buffer;
 } cfg_t;
 

--- a/debug.c
+++ b/debug.c
@@ -1,73 +1,31 @@
 /*
- * Copyright (C) 2021 Yubico AB - See COPYING
+ * Copyright (C) 2021-2025 Yubico AB - See COPYING
  */
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <stdarg.h>
 #include <string.h>
 #include <syslog.h>
-#include <unistd.h>
 
 #include "debug.h"
 
 #define DEBUG_FMT "debug(pam_u2f): %s:%d (%s): %s%s"
 #define MSGLEN 2048
 
-FILE *debug_open(const char *filename) {
-  struct stat st;
-  FILE *file;
-  int fd;
-
-  if (strcmp(filename, "stdout") == 0)
-    return stdout;
-  if (strcmp(filename, "stderr") == 0)
-    return stderr;
-  if (strcmp(filename, "syslog") == 0)
-    return NULL;
-
-  fd = open(filename, O_WRONLY | O_APPEND | O_CLOEXEC | O_NOFOLLOW | O_NOCTTY);
-  if (fd == -1 || fstat(fd, &st) != 0)
-    goto err;
-
-#ifndef WITH_FUZZING
-  if (!S_ISREG(st.st_mode))
-    goto err;
-#endif
-
-  if ((file = fdopen(fd, "a")) != NULL)
-    return file;
-
-err:
-  if (fd != -1)
-    close(fd);
-
-  return DEFAULT_DEBUG_FILE; /* fallback to default */
-}
-
-void debug_close(FILE *f) {
-  if (f != NULL && f != stdout && f != stderr)
-    fclose(f);
-}
-
-static void do_log(FILE *debug_file, const char *file, int line,
-                   const char *func, const char *msg, const char *suffix) {
-#ifndef WITH_FUZZING
-  if (debug_file == NULL) {
-    syslog(LOG_AUTHPRIV | LOG_DEBUG, DEBUG_FMT, file, line, func, msg, suffix);
-  } else {
-    fprintf(debug_file, DEBUG_FMT "\n", file, line, func, msg, suffix);
-  }
-#else
-  (void) debug_file;
+static void do_log(const char *file, int line, const char *func,
+                   const char *msg, const char *suffix) {
+#if defined(WITH_FUZZING)
   snprintf(NULL, 0, DEBUG_FMT, file, line, func, msg, suffix);
+#elif defined(PAM_U2F_TESTING)
+  fprintf(stderr, DEBUG_FMT, file, line, func, msg, suffix);
+  fputc('\n', stderr);
+#else
+  syslog(LOG_AUTHPRIV | LOG_DEBUG, DEBUG_FMT, file, line, func, msg, suffix);
 #endif
 }
 
-ATTRIBUTE_FORMAT(printf, 5, 0)
-static void debug_vfprintf(FILE *debug_file, const char *file, int line,
-                           const char *func, const char *fmt, va_list args) {
+ATTRIBUTE_FORMAT(printf, 4, 0)
+static void debug_vfprintf(const char *file, int line, const char *func,
+                           const char *fmt, va_list args) {
   const char *bn;
   char msg[MSGLEN];
   int r;
@@ -76,17 +34,17 @@ static void debug_vfprintf(FILE *debug_file, const char *file, int line,
     file = bn + 1;
 
   if ((r = vsnprintf(msg, sizeof(msg), fmt, args)) < 0)
-    do_log(debug_file, file, line, func, __func__, "");
+    do_log(file, line, func, __func__, "");
   else
-    do_log(debug_file, file, line, func, msg,
+    do_log(file, line, func, msg,
            (size_t) r < sizeof(msg) ? "" : "[truncated]");
 }
 
-void debug_fprintf(FILE *debug_file, const char *file, int line,
-                   const char *func, const char *fmt, ...) {
+void debug_printf(const char *file, int line, const char *func, const char *fmt,
+                  ...) {
   va_list ap;
 
   va_start(ap, fmt);
-  debug_vfprintf(debug_file, file, line, func, fmt, ap);
+  debug_vfprintf(file, line, func, fmt, ap);
   va_end(ap);
 }

--- a/debug.h
+++ b/debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Yubico AB - See COPYING
+ * Copyright (C) 2021-2025 Yubico AB - See COPYING
  */
 
 #ifndef DEBUG_H
@@ -7,19 +7,16 @@
 
 #include <stdio.h>
 
-#define DEFAULT_DEBUG_FILE stderr
-
 #if defined(DEBUG_PAM)
-#define D(file, ...)                                                           \
-  debug_fprintf(file, __FILE__, __LINE__, __func__, __VA_ARGS__)
+#define D(...) debug_printf(__FILE__, __LINE__, __func__, __VA_ARGS__)
 #else
-#define D(file, ...) ((void) 0)
+#define D(...) ((void) 0)
 #endif /* DEBUG_PAM */
 
 #define debug_dbg(cfg, ...)                                                    \
   do {                                                                         \
     if (cfg->debug) {                                                          \
-      D(cfg->debug_file, __VA_ARGS__);                                         \
+      D(__VA_ARGS__);                                                          \
     }                                                                          \
   } while (0)
 
@@ -29,9 +26,7 @@
 #define ATTRIBUTE_FORMAT(f, s, a)
 #endif
 
-FILE *debug_open(const char *);
-void debug_close(FILE *f);
-void debug_fprintf(FILE *, const char *, int, const char *, const char *, ...)
-  ATTRIBUTE_FORMAT(printf, 5, 6);
+void debug_printf(const char *, int, const char *, const char *, ...)
+  ATTRIBUTE_FORMAT(printf, 4, 5);
 
 #endif /* DEBUG_H */

--- a/fuzz/fuzz_auth.c
+++ b/fuzz/fuzz_auth.c
@@ -70,8 +70,7 @@ static const char dummy_conf_file[] = "max_devices=10\n"
                                       "origin=pam://lolcalhost\n"
                                       "appid=pam://lolcalhost\n"
                                       "prompt=hello\n"
-                                      "cue_prompt=howdy\n"
-                                      "debug_file=stdout\n";
+                                      "cue_prompt=howdy\n";
 
 /* conversation dummy for manual authentication */
 static const char *dummy_conv =

--- a/man/pam_u2f.8.txt
+++ b/man/pam_u2f.8.txt
@@ -16,15 +16,7 @@ compliant authenticators.
 
 == OPTIONS
 *debug*::
-Enables debug output
-
-*debug_file*::
-Filename to write debugging messages to. **If this file is missing,
-nothing will be logged**. This regular file **has to be created by the
-user** or **must exist and be a regular file** for anything getting
-logged to it. It is not created by pam-u2f on purpose (for security
-considerations). This filename may be alternatively set to "stderr"
-(default), "stdout", or "syslog".
+Enables debug output to syslog(3).
 
 *origin*=_origin_::
 Set the relying party ID for the FIDO authentication procedure. If no

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,7 +12,7 @@ dlsym_check_LDFLAGS = -ldl $(AM_LDFLAGS)
 
 # XXX move openbsd-compat
 check_PROGRAMS += get_devices
-get_devices_SOURCES = get_devices.c
+get_devices_SOURCES = get_devices.c mock_syslog.c
 get_devices_LDADD = $(top_builddir)/libmodule.la
 
 check_PROGRAMS += expand

--- a/tests/cfg.c
+++ b/tests/cfg.c
@@ -128,11 +128,6 @@ static void config_flip_all(const struct conf_file *cf, const cfg_t *cfg) {
 
   fprintf(conf_out, "max_devices=%d\n", cfg->max_devs + 1);
 
-  if (cfg->debug_file)
-    fprintf(conf_out, "debug_file=syslog\n");
-  else
-    fprintf(conf_out, "debug_file=stderr\n");
-
   fflush(conf_out);
 }
 
@@ -194,8 +189,6 @@ static void test_regular(void) {
   assert(str_opt_cmp(cfg.appid, cfg_defaults.appid));
   assert(str_opt_cmp(cfg.prompt, cfg_defaults.prompt));
   assert(str_opt_cmp(cfg.cue_prompt, cfg_defaults.cue_prompt));
-
-  assert(cfg.debug_file != cfg_defaults.debug_file);
 
   cfg_free(&cfg_defaults);
   cfg_free(&cfg);

--- a/tests/get_devices.c
+++ b/tests/get_devices.c
@@ -22,7 +22,6 @@ static void test_nouserok(const char *username) {
   memset(&cfg, 0, sizeof(cfg_t));
   cfg.auth_file = "credentials/this_file_does_not_exist.cred";
   cfg.debug = 1;
-  cfg.debug_file = stderr;
   cfg.max_devs = 1;
   cfg.nouserok = 1;
 
@@ -48,7 +47,6 @@ static void test_ssh_credential(const char *username) {
   memset(&cfg, 0, sizeof(cfg_t));
   cfg.auth_file = "credentials/ssh_credential.cred";
   cfg.debug = 1;
-  cfg.debug_file = stderr;
   cfg.max_devs = 1;
   cfg.sshformat = 1;
 
@@ -80,7 +78,6 @@ static void test_old_credential(const char *username) {
   cfg.auth_file = "credentials/old_credential.cred";
   cfg.sshformat = 0;
   cfg.debug = 1;
-  cfg.debug_file = stderr;
   cfg.max_devs = 1;
   cfg.sshformat = 0;
 
@@ -110,7 +107,6 @@ static void test_limited_count(const char *username) {
 
   memset(&cfg, 0, sizeof(cfg_t));
   cfg.debug = 1;
-  cfg.debug_file = stderr;
 
   /* authfile contains three credentials (eddsa, es256, eddsa) */
   cfg.auth_file = "credentials/new_limited_count.cred";
@@ -169,7 +165,6 @@ static void test_new_credentials(const char *username) {
 
   memset(&cfg, 0, sizeof(cfg_t));
   cfg.debug = 1;
-  cfg.debug_file = stderr;
   cfg.max_devs = 24;
 
   /* clang-format off */

--- a/tests/mock_syslog.c
+++ b/tests/mock_syslog.c
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (C) 2014-2025 Yubico AB - See COPYING
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <syslog.h>
+
+/* XXX: force all debug output to stderr */
+void syslog(int priority, const char *message, ...) {
+  va_list ap;
+
+  (void) priority;
+
+  va_start(ap, message);
+  vfprintf(stderr, message, ap);
+  va_end(ap);
+  fputc('\n', stderr);
+}

--- a/util.c
+++ b/util.c
@@ -712,6 +712,11 @@ int get_devices_from_authfile(const cfg_t *cfg, const char *username,
   }
 
   if ((st.st_mode & (S_IWGRP | S_IWOTH)) != 0) {
+    /* FIXME: make this a hard error (goto err).
+     *
+     * Currently not the case, since treating this as error has proven to
+     * break existing installations.
+     */
 #ifndef WITH_FUZZING
     syslog(LOG_AUTHPRIV | LOG_WARNING,
            "warning(pam_u2f): Permissions %04o for '%s' are too open. Please "

--- a/util.c
+++ b/util.c
@@ -712,16 +712,7 @@ int get_devices_from_authfile(const cfg_t *cfg, const char *username,
   }
 
   if ((st.st_mode & (S_IWGRP | S_IWOTH)) != 0) {
-    /* XXX: attempt to prevent two messages to syslog */
-    if (cfg->debug_file) {
-      debug_dbg(cfg,
-                "Permissions %04o for '%s' are too open. Please change the "
-                "file mode bits to 0644 or more restrictive. This may become "
-                "an error in the future!",
-                (unsigned int) st.st_mode & 0777, cfg->auth_file);
-    }
 #ifndef WITH_FUZZING
-    /* XXX: force a message to syslog, regardless of the debug level */
     syslog(LOG_AUTHPRIV | LOG_WARNING,
            "warning(pam_u2f): Permissions %04o for '%s' are too open. Please "
            "change the file mode bits to 0644 or more restrictive. This may "


### PR DESCRIPTION
We are removing the `debug_file=` option, both from the pam_u2f.so arguments and configuration.

The module loses the ability to send debug info towards a file or stdout. It is still possible to log on stderr via syslog, e.g.
```c
openlog(argv[0], LOG_PERROR, 0);
```

This is a breaking change, so it is targeting the `next` branch instead of `main`, meaning that these change will flow into the first scheduled _major bump_.