### PR TITLE
Terminology updates

### DIFF
--- a/README
+++ b/README
@@ -215,7 +215,7 @@ appid=appid::
 Set the https://developers.yubico.com/U2F/App_ID.html[application ID]
 for the FIDO authentication procedure. If no value is specified, the
 same value used for origin is taken ("pam://$HOSTNAME" if also origin
-is not specified). This setting is only applicable for U2F credentials
+is not specified). This setting is only applicable for FIDO credentials
 created with pamu2fcfg versions v1.0.8 or earlier. Note that on v1.1.0
 and v1.1.1 of pam-u2f, handling of this setting was temporarily broken
 if the value was not the same as the value of origin.
@@ -236,8 +236,8 @@ sequences result in an authentication error. See also `openasuser`.
 authpending_file=file::
 Set the location of the file that is used for touch request
 notifications. This file will be opened when pam-u2f starts waiting
-for a user to touch the device, and will be closed when it no longer
-waits for a touch. Use inotify to listen on these events, or a more
+for a user to touch the FIDO authenticator, and will be closed when it no
+longer waits for a touch. Use inotify to listen on these events, or a more
 high-level tool like
 https://github.com/maximbaz/yubikey-touch-detector[yubikey-touch-detector].
 Note that yubikey-touch-detector v1.5.1 and later no longer rely on the
@@ -263,13 +263,14 @@ Set to enable all authentication attempts to succeed (aka presentation
 mode).
 
 max_devices=n_devices::
-Maximum number of devices (credentials) allowed per user (default is 24).
-Devices specified in the authorization mapping file that exceed this value will
-be ignored.
+Maximum number of FIDO authenticators allowed per user (default is 24).
+Authenticators specified in the authorization mapping file that exceed
+this value will be ignored.
 
 interactive::
 Set to prompt a message and wait before testing the presence of a FIDO
-device. Recommended if your device doesn't have a tactile trigger.
+authenticator. Recommended if your authenticator doesn't have a tactile
+trigger.
 
 [prompt=your prompt here]::
 Set individual prompt message for interactive mode. Watch the square
@@ -279,11 +280,11 @@ PAM.
 manual::
 Set to drop to a manual console where challenges are printed on screen
 and response read from standard input. Useful for debugging and SSH
-sessions without U2F-support from the SSH client/server. If enabled,
+sessions without FIDO support from the SSH client/server. If enabled,
 interactive mode becomes redundant and has no effect.
 
 cue::
-Set to prompt a message to remind to touch the device.
+Set to prompt a message to remind to touch the FIDO authenticator.
 
 [cue_prompt=your prompt here]::
 Set individual prompt message for the cue option. Watch the square
@@ -291,7 +292,7 @@ brackets around this parameter to get spaces correctly recognized by
 PAM.
 
 nodetect::
-Set to skip detecting if a suitable FIDO token is inserted before
+Set to skip detecting if a suitable FIDO authenticator is inserted before
 performing the full tactile authentication. This detection was created
 to avoid emitting the "cue" message if no suitable token exists,
 because doing so leaks information about the authentication stack if a
@@ -321,7 +322,7 @@ with support for a FIDO2 PIN is required.
 
 sshformat::
 Use credentials produced by versions of OpenSSH that have support for
-FIDO devices. It is not possible to mix native credentials and SSH
+FIDO authenticators. It is not possible to mix native credentials and SSH
 credentials. Once this option is enabled all credentials will be parsed
 as SSH.
 
@@ -486,12 +487,12 @@ To use this credential the `authfile` parameter should be set to the path of
 the file `credential.ssh` and the `sshformat` option should also be set. If the
 `authfile` parameter is not set, it defaults to `~/.ssh/id_ecdsa_sk`.
 
-=== Multiple Devices
+=== Multiple FIDO Authenticators
 
-Multiple devices (credentials) are supported. If more than one credential is
+Multiple FIDO authenticators are supported. If more than one authenticator is
 specified, authentication against them is attempted sequentially as they are
 defined in the authorization mapping file. If during an authentication attempt
-a connected device is removed or a new device is plugged in, the authentication
+a connected authenticator is removed or a new one is plugged in, the authentication
 restarts from the top of the list.
 
 [[confFile]]
@@ -543,8 +544,8 @@ For more information see
 https://access.redhat.com/security/cve/CVE-2020-24612[HERE].
 
 == FIDO U2F vs FIDO2
-Devices that solely support FIDO U2F and not FIDO2, e.g. the YubiKey 4 series,
-can be used only in conjunction with compatible features. Enabling incompatible
-features, such as setting the `+pin` or the `+verification` flags in the
-`authfile` or the corresponding options in the PAM service configuration causes
-the device to be ignored.
+Authenticators that solely support FIDO U2F and not FIDO2, e.g. the YubiKey 4
+series, can be used only in conjunction with compatible features. Enabling
+incompatible features, such as setting the `+pin` or the `+verification` flags
+in the `authfile` or the corresponding options in the PAM service configuration
+causes the authenticator to be ignored.

--- a/man/pam_u2f.8.txt
+++ b/man/pam_u2f.8.txt
@@ -31,10 +31,10 @@ Set the relying party ID for the FIDO authentication procedure. If no
 value is specified, the identifier "pam://$HOSTNAME" is used.
 
 *appid*=_appid_::
-Set the application ID for the U2F authentication
+Set the application ID for the FIDO authentication
 procedure. If no value is specified, the same value used for origin is
 taken ("pam://$HOSTNAME" if also origin is not specified). This setting
-is only applicable for U2F credentials created with pamu2fcfg versions
+is only applicable for FIDO credentials created with pamu2fcfg versions
 v1.0.8 or earlier. Note that on v1.1.0 and v1.1.1 of pam-u2f, handling
 of this setting was temporarily broken if the value was not the same as
 the value of origin.
@@ -54,13 +54,14 @@ local user name (`PAM_USER`) and `%%` is expanded to `%`. Unknown expansion
 sequences result in an authentication error. See also `openasuser`.
 
 *authpending_file*=_file_::
-Set the location of the file that is used for touch request
-notifications. This file will be opened when pam-u2f starts waiting
-for a user to touch the device, and will be closed when it no longer
-waits for a touch. Use inotify to listen on these events, or a more
-high-level tool like yubikey-touch-detector. Default value:
-/var/run/user/$UID/pam-u2f-authpending. Set an empty value in order to
-disable this functionality, like so: "authpending_file=".
+Set the location of the file that is used for touch request notifications. This
+file will be opened when pam-u2f starts waiting for a user to touch the FIDO
+authenticator, and will be closed when it no longer waits for a touch. Use
+inotify to listen on these events, or a more high-level tool like
+yubikey-touch-detector.
+Default value: /var/run/user/$UID/pam-u2f-authpending.
+Set an empty value in order to disable this functionality, like so:
+"authpending_file=".
 
 *nouserok*::
 Set to enable authentication attempts to succeed even if the user
@@ -80,13 +81,13 @@ Set to enable all authentication attempts to succeed (aka presentation
 mode).
 
 *max_devices*=_n_devices_::
-Maximum number of devices (credentials) allowed per user (default is 24).
-Devices specified in the authorization mapping file that exceed this value
-will be ignored.
+Maximum number of FIDO authenticators allowed per user (default is 24).
+FIDO authenticators specified in the authorization mapping file that exceed
+this value will be ignored.
 
 *interactive*::
-Set to prompt a message and wait before testing the presence of a U2F
-device. Recommended if your device doesn't have tactile trigger.
+Set to prompt a message and wait before testing the presence of a FIDO
+authenticator. Recommended if your authenticator doesn't have tactile trigger.
 
 *[prompt=your prompt here]*::
 Set individual prompt message for interactive mode. Watch the square
@@ -96,11 +97,11 @@ PAM.
 *manual*::
 Set to drop to a manual console where challenges are printed on screen
 and response read from standard input. Useful for debugging and SSH
-sessions without U2F-support from the SSH client/server. If enabled,
+sessions without FIDO support from the SSH client/server. If enabled,
 interactive mode becomes redundant and has no effect.
 
 *cue*::
-Set to prompt a message to remind to touch the device.
+Set to prompt a message to remind to touch the FIDO authenticator.
 
 *[cue_prompt=your prompt here]*::
 Set individual prompt message for the cue option. Watch the square
@@ -108,8 +109,8 @@ brackets around this parameter to get spaces correctly recognized by
 PAM.
 
 *nodetect*::
-Skip detecting if a suitable key is inserted before performing a full
-authentication. See *NOTES* below.
+Skip detecting if a suitable FIDO authenticator is inserted before performing a
+full authentication. See *NOTES* below.
 
 *userpresence*=_int_::
 If 1, require user presence during authentication. If 0, do not
@@ -130,7 +131,7 @@ support for a FIDO2 PIN is required.
 
 *sshformat*::
 Use credentials produced by versions of OpenSSH that have support for
-FIDO devices. It is not possible to mix native credentials and SSH
+FIDO authenticator. It is not possible to mix native credentials and SSH
 credentials. Once this option is enabled all credentials will be parsed
 as SSH.
 
@@ -210,8 +211,8 @@ determine that pam_u2f is part of the authentication stack by
 inserting any random U2F token and performing an authentication
 attempt. In this scenario, the attacker would see the cue message
 followed by an immediate failure, whereas with detection enabled, the
-U2F authentication will fail silently. Understand that an attacker
-could choose a U2F token that alerts him or her in some way to the
+authentication will fail silently. Understand that an attacker
+could choose an authenticator that alerts him or her in some way to the
 "check-only" authentication attempt, so this precaution only pushes
 the issue back a step.
 

--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -391,8 +391,8 @@ static void parse_args(int argc, char *argv[], struct args *args) {
 "  -V, --user-verification  Require user verification during authentication\n"
 "  -d, --debug              Print debug information\n"
 "  -v, --verbose            Print information about chosen origin and appid\n"
-"  -u, --username=STRING    The name of the user registering the device,\n"
-"                             defaults to the current user name\n"
+"  -u, --username=STRING    The name of the user registering the FIDO\n"
+"                             authenticator, defaults to the current user name\n"
 "  -n, --nouser             Print only registration information (key handle,\n"
 "                             public key, and options), useful for appending\n"
 "\n"
@@ -475,15 +475,15 @@ int main(int argc, char *argv[]) {
 
   r = fido_dev_info_manifest(devlist, DEVLIST_LEN, &ndevs);
   if (r != FIDO_OK) {
-    fprintf(stderr, "Unable to discover device(s), %s (%d)\n", fido_strerr(r),
-            r);
+    fprintf(stderr, "Unable to discover FIDO authenticator(s), %s (%d)\n",
+            fido_strerr(r), r);
     goto err;
   }
 
   if (ndevs == 0) {
     for (int i = 0; i < TIMEOUT; i += FREQUENCY) {
       fprintf(stderr,
-              "\rNo U2F device available, please insert one now, you "
+              "\rNo FIDO authenticator available, please insert one now, you "
               "have %2d seconds",
               TIMEOUT - i);
       fflush(stderr);
@@ -491,21 +491,21 @@ int main(int argc, char *argv[]) {
 
       r = fido_dev_info_manifest(devlist, DEVLIST_LEN, &ndevs);
       if (r != FIDO_OK) {
-        fprintf(stderr, "\nUnable to discover device(s), %s (%d)",
+        fprintf(stderr, "\nUnable to discover FIDO authenticator(s), %s (%d)\n",
                 fido_strerr(r), r);
         goto err;
       }
 
       if (ndevs != 0) {
-        fprintf(stderr, "\nDevice found!\n");
+        fprintf(stderr, "\nFIDO authenticator found!\n");
         break;
       }
     }
   }
 
   if (ndevs == 0) {
-    fprintf(stderr, "\rNo device found. Aborting.                              "
-                    "           \n");
+    fprintf(stderr, "\rNo FIDO authenticator found. Aborting.                  "
+                    "                   \n");
     goto err;
   }
 
@@ -537,14 +537,16 @@ int main(int argc, char *argv[]) {
     goto err;
   }
   if (args.pin_verification && !(devopts & PIN_SET)) {
-    warnx("%s", devopts & PIN_UNSET ? "device has no PIN"
-                                    : "device does not support PIN");
+    warnx("%s", devopts & PIN_UNSET
+                  ? "FIDO authenticator has no PIN"
+                  : "FIDO authenticator does not support PIN");
     goto err;
   }
   if (args.user_verification && !(devopts & UV_SET)) {
-    warnx("%s", devopts & UV_UNSET
-                  ? "device has no built-in user verification configured"
-                  : "device does not support built-in user verification");
+    warnx("%s",
+          devopts & UV_UNSET
+            ? "FIDO authenticator has no built-in user verification configured"
+            : "FIDO authenticator does not support built-in user verification");
     goto err;
   }
   if ((devopts & (UV_REQD | PIN_SET | UV_SET)) == UV_REQD) {

--- a/util.c
+++ b/util.c
@@ -633,10 +633,11 @@ static int parse_ssh_format(const cfg_t *cfg, FILE *opwfile,
     goto out;
   }
 
-  debug_dbg(cfg, "KeyHandle for device number 1: %s", devices[0].keyHandle);
-  debug_dbg(cfg, "publicKey for device number 1: %s", devices[0].publicKey);
-  debug_dbg(cfg, "COSE type for device number 1: %s", devices[0].coseType);
-  debug_dbg(cfg, "Attributes for device number 1: %s", devices[0].attributes);
+  debug_dbg(cfg, "KeyHandle for device number %u: %s", 1, devices[0].keyHandle);
+  debug_dbg(cfg, "publicKey for device number %u: %s", 1, devices[0].publicKey);
+  debug_dbg(cfg, "COSE type for device number %u: %s", 1, devices[0].coseType);
+  debug_dbg(cfg, "Attributes for device number %u: %s", 1,
+            devices[0].attributes);
 
   // reserved (skip)
   if (!ssh_get_string_ref(&decoded, &decoded_len, NULL, NULL)) {

--- a/util.h
+++ b/util.h
@@ -18,8 +18,8 @@
 #define DEFAULT_AUTHFILE_DIR ".config"
 #define DEFAULT_AUTHFILE_DIR_SSH ".ssh"
 #define DEFAULT_AUTHPENDING_FILE_PATH "/var/run/user/%d/pam-u2f-authpending"
-#define DEFAULT_PROMPT "Insert your U2F device, then press ENTER."
-#define DEFAULT_CUE "Please touch the device."
+#define DEFAULT_PROMPT "Insert your FIDO authenticator, then press ENTER."
+#define DEFAULT_CUE "Please touch the FIDO authenticator."
 #define DEFAULT_ORIGIN_PREFIX "pam://"
 #define SSH_ORIGIN "ssh:"
 


### PR DESCRIPTION
Change references to "devices" / "authenticators" / "tokens" to "FIDO authenticator".

The change affects only user prompts, README and manpages, while log lines are kept as they are, at least for now.