### PR TITLE
util: return PAM_CRED_UNAVAIL from do_authentication() if no suitable devices are connected

### DIFF
--- a/util.c
+++ b/util.c
@@ -1166,6 +1166,7 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
   int retval = PAM_AUTH_ERR;
   size_t ndevs = 0;
   size_t ndevs_prev = 0;
+  size_t ndevs_suitable = 0;
   unsigned i = 0;
   struct opts opts;
   struct pk pk;
@@ -1246,6 +1247,7 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
           goto out;
         }
 
+        ++ndevs_suitable;
         if (opts.pin == FIDO_OPT_TRUE) {
           pin = converse(pamh, PAM_PROMPT_ECHO_OFF, "Please enter the PIN: ");
           if (pin == NULL) {
@@ -1307,6 +1309,7 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
                 "Devices max_index has changed: %zu (was %zu). Starting over",
                 ndevs, ndevs_prev);
       ndevs_prev = ndevs;
+      ndevs_suitable = 0;
       i = 0;
     }
 
@@ -1316,6 +1319,11 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
     }
 
     fido_assert_free(&assert);
+  }
+
+  if (ndevs_suitable == 0) {
+    debug_dbg(cfg, "No suitable devices found");
+    retval = PAM_CRED_UNAVAIL;
   }
 
 out:


### PR DESCRIPTION
Allows the case from #322 to be handled with the PAM stack. Comments re: suitability of return code and any other pits I may have fallen in welcome.