### PR TITLE
ci: drop ubuntu 20.04 runners

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -13,8 +13,6 @@ jobs:
           - { os: ubuntu-24.04, cc: clang-18 }
           - { os: ubuntu-22.04, cc: gcc-12 }
           - { os: ubuntu-22.04, cc: clang-15 }
-          - { os: ubuntu-20.04, cc: gcc-10 }
-          - { os: ubuntu-20.04, cc: clang-11 }
     steps:
     - uses: actions/checkout@v4
     - name: dependencies


### PR DESCRIPTION
Will be removed by GitHub 2025-04-01.