### PR TITLE
Adjust prompt to omit non-human information

### DIFF
--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -201,12 +201,7 @@ static int make_cred(const struct args *args, const char *path, fido_dev_t *dev,
   if ((devopts & PIN_SET) &&
       (r == FIDO_ERR_PIN_REQUIRED || r == FIDO_ERR_UV_BLOCKED ||
        r == FIDO_ERR_PIN_BLOCKED)) {
-    n = snprintf(prompt, sizeof(prompt), "Enter PIN for %s: ", path);
-    if (n < 0 || (size_t) n >= sizeof(prompt)) {
-      fprintf(stderr, "error: snprintf prompt");
-      return -1;
-    }
-    if (!readpassphrase(prompt, pin, sizeof(pin), RPP_ECHO_OFF)) {
+    if (!readpassphrase("Enter PIN (then touch device): ", pin, sizeof(pin), RPP_ECHO_OFF)) {
       fprintf(stderr, "error: failed to read pin");
       explicit_bzero(pin, sizeof(pin));
       return -1;


### PR DESCRIPTION
Revisiting some changes I've long wanted upstream (#319  but those commits were messy). 

User observations show they:

1. do not understand the random-seeming values coming from the `path`. It is not a value add and actually a usability issue.
2. Wait after entering the pin for nothing happening as the device is flashing (often discreetly) waiting to be touched. 

Address both by changing the prompt.