### PR TITLE
Change behavior from a silent overwrite of prior auth to a cumulation

### DIFF
--- a/util.c
+++ b/util.c
@@ -230,13 +230,8 @@ static int parse_native_format(const cfg_t *cfg, const char *username,
     if (s_user && strcmp(username, s_user) == 0) {
       debug_dbg(cfg, "Matched user: %s", s_user);
 
-      // only keep last line for this user
-      for (i = 0; i < *n_devs; i++) {
-        reset_device(&devices[i]);
-      }
-      *n_devs = 0;
-
-      i = 0;
+      // keep all lines/devices as a cumulative set of authorized credentials
+      i = *n_devs;
       while ((s_credential = strtok_r(NULL, ":", &saveptr))) {
         if ((*n_devs)++ > cfg->max_devs - 1) {
           *n_devs = cfg->max_devs;


### PR DESCRIPTION
Re-propose what was proposed in #305 in hopes of making the next major version.

*What it does*
The current solution takes a line of `UserBob dev1 dev2` as a signal to replace any prior authorization of `UserBob` with only those devices listed on this line. In this case `dev1` and `dev2`.

The proposal here is to allow multiple lines so if there was a prior `UserBob devA devB` then the set of authorized devices is all of A, B, 1 and 2.

*Why this is an improvement and the current pam-u2f solution is poor*

The best arguments for the current solution is that it is the current behavior. However,deletion of a line - moving from a world of `UserBob devA; UserBob dev1` by deleting dev1 and ending up with (on some prior line perhaps far away) `UserBob devA` - has an insecure and perverse impact of re-enabling `devA`. Use of new lines to mute the meaning of old lines is a behavior begging for a security incident and should not be encouraged.

This change is notionally in line with the idea of being more declarative than mutable.